### PR TITLE
[다재다능 코틀린 프로그래밍] Ch02 - Java 개발자를 위한 코틀린 필수 사항

### DIFF
--- a/kotlin-programming/src/main/kotlin/ch02/equality.kts
+++ b/kotlin-programming/src/main/kotlin/ch02/equality.kts
@@ -1,0 +1,5 @@
+println("hi" == "hi")   //true
+println("hi" == "Hi")   //false
+println(null == "hi")   //false
+println("hi" == null)   //false
+println(null == null)   //true

--- a/kotlin-programming/src/main/kotlin/ch02/ifExpression.kts
+++ b/kotlin-programming/src/main/kotlin/ch02/ifExpression.kts
@@ -1,0 +1,18 @@
+fun canVoteExpression(name: String, age: Int): String {
+    var status: String
+    if (age > 17) { //명령문 - 리턴값이 없다. 따라서 뮤터블 변수 status를 만들어서, 메소드 안에서 해당 변수를 수정해야 한다.
+        status = "yes, please vote!"
+    } else {
+        status = "nope, please come back!"
+    }
+
+    return "$name, $status"
+}
+
+fun canVoteStatement(name: String, age: Int): String {
+    val status = if (age > 17) "yes, please vote!" else "nope, please come back!" //표현식 - if를 호출하고, 결과를 사용할 수 있따.
+    return "$name, $status"
+}
+
+println(canVoteExpression("Solar", 20))
+println(canVoteStatement("Solar", 15))

--- a/kotlin-programming/src/main/kotlin/ch02/memo.kts
+++ b/kotlin-programming/src/main/kotlin/ch02/memo.kts
@@ -1,0 +1,7 @@
+val name = "Solar"
+
+val memo = """Dear $name, a quick reminder about the 
+party we have scheduled next Tuesday at 
+the 'Low Ceremony Cafe' at Noon. | Please plan to..."""
+
+println(memo)

--- a/kotlin-programming/src/main/kotlin/ch02/mutate.kts
+++ b/kotlin-programming/src/main/kotlin/ch02/mutate.kts
@@ -1,0 +1,5 @@
+var factor = 2
+fun doubleIt(number: Int) = number * factor
+factor = 0
+
+println(doubleIt(2))

--- a/kotlin-programming/src/main/kotlin/ch02/mutateConfusion.kts
+++ b/kotlin-programming/src/main/kotlin/ch02/mutateConfusion.kts
@@ -1,0 +1,7 @@
+var factor = 2 //var보다 val을 사용해야한다.
+fun doubleIt(number: Int) = number * factor //호출할 때 factor의 값으로 사용된다.
+var message = "The factor is $factor" //message를 만들 시점의 factor의 값은 2
+factor = 0
+
+println(doubleIt(2))    //0
+println(message)    //The factor is 2

--- a/kotlin-programming/src/main/kotlin/ch02/nestedMemo.kts
+++ b/kotlin-programming/src/main/kotlin/ch02/nestedMemo.kts
@@ -1,0 +1,12 @@
+fun createMemoFor(name: String): String {
+    if (name == "Solar") {
+        val memo = """Dear $name, a quick reminder about the 
+            party we have scheduled next Tuesday at
+            the 'Low Ceremony Cafe' at Noon. | Please plan to..."""
+        return memo
+    }
+
+    return ""
+}
+
+println(createMemoFor("Solar"))

--- a/kotlin-programming/src/main/kotlin/ch02/nestedMemoFix.kts
+++ b/kotlin-programming/src/main/kotlin/ch02/nestedMemoFix.kts
@@ -1,0 +1,12 @@
+fun createMemoFor(name: String): String {
+    if (name == "Solar") {
+        val memo = """Dear $name, a quick reminder about the 
+            |party we have scheduled next Tuesday at
+            |the 'Low Ceremony Cafe' at Noon. | Please plan to..."""
+        return memo.trimMargin()
+    }
+
+    return ""
+}
+
+println(createMemoFor("Solar"))

--- a/kotlin-programming/src/main/kotlin/ch02/nocatch.kts
+++ b/kotlin-programming/src/main/kotlin/ch02/nocatch.kts
@@ -1,0 +1,5 @@
+package ch02
+
+println("Hello")
+Thread.sleep(1000) //sleep() 메소드는 명시적 예외를 전달한다. try~catch를 강제하지 않는다.
+println("World.")

--- a/kotlin-programming/src/main/kotlin/ch02/standalone.kts
+++ b/kotlin-programming/src/main/kotlin/ch02/standalone.kts
@@ -1,0 +1,14 @@
+package ch02
+
+fun nofluff() {
+    println("nofluff called...")
+    throw RuntimeException("oops")
+}
+println("not in a function, calling nofluff()")
+try {
+    nofluff()
+} catch (ex: Exception) {
+    val stackTrace = ex.getStackTrace()
+    println(stackTrace[0])
+    println(stackTrace[1])
+}

--- a/kotlin-programming/src/main/kotlin/ch02/stringTemplate.kts
+++ b/kotlin-programming/src/main/kotlin/ch02/stringTemplate.kts
@@ -1,0 +1,7 @@
+var price = 12.25
+var taxRate = 0.08
+var output = "The amount $price after tax comes to $${price * (1 + taxRate)}"
+var disclaimer = "The amount is in US$, that's right in \$only"
+
+println(output)
+println(disclaimer)

--- a/kotlin-programming/src/main/kotlin/ch02/tryExpression.kts
+++ b/kotlin-programming/src/main/kotlin/ch02/tryExpression.kts
@@ -1,0 +1,15 @@
+fun tryExpression(blowup: Boolean): Int {
+    return try {
+        if (blowup) {
+            throw RuntimeException("fail!!!!!")
+        }
+        2
+    } catch (e: Exception) {
+        4
+    } finally {
+
+    }
+}
+
+println(tryExpression(false)) //2
+println(tryExpression(true)) //4

--- a/kotlin-programming/src/main/kotlin/ch02/typeinference.kts
+++ b/kotlin-programming/src/main/kotlin/ch02/typeinference.kts
@@ -1,0 +1,8 @@
+package ch02
+
+val greet = "hello"
+println(greet) //hello
+println(greet::class) //class kotlin.String //변수에 의해 참조되고 있는 객체의 코틀린 클래스를 확인
+println(greet.javaClass) //class java.lang.String //Java 클래스를 확인
+
+//greet = 0 //컴파일 시점에 greet 타입이 문자열이라고 판단한다. (타입 추론) 타입이 맞기 않아 컴파일 오류가 발생

--- a/kotlin-programming/src/main/kotlin/ch02/unusedWarning.kts
+++ b/kotlin-programming/src/main/kotlin/ch02/unusedWarning.kts
@@ -1,0 +1,4 @@
+package ch02
+
+fun compute(n: Int) = 0
+println(compute(4))


### PR DESCRIPTION
# CH02 Java 개발자를 위한 코틀린 필수 사항

Java에서 익숙하게 봤떠라도 코틀린에 적용하려면 조정해야 하는 부분을 살펴본다.

코틀린은 세미콜론, 타입 정의, 클래스 등 다른 언어에서는 필수적인 것들을 몇 가지 선택사항(optional)로 만들었다.

변수를 만들 때 뮤터블(mutable, 변경 가능)인지, 이뮤터블(immutable, 변경 불가능)인지를 결정해야 한다.

# 2-1.  더 적은 타이핑

## 세미콜론은 생략해도 된다. (사용하지 않는 것을 권장)

## 변수 타입 지정은 생략해도 된다.

```kotlin
val greet = "hello"
println(greet)
println(greet::class) //변수에 의해 참조되고 있는 객체의 코틀린 클래스를 확인
println(greet.javaClass) //Java 클래스를 확인

//greet = 0 //컴파일 시점에 greet 타입이 문자열이라고 판단한다. (타입 추론) 타입이 맞기 않아 컴파일 오류가 발생
```

```jsx
//실행결과
hello
class kotlin.String
class java.lang.String
```

- 컴파일 시점에 타입을 판단
- 타입이 명확한 경우에는 타입을 생략할 수 있다.
- 함수나 메소드를 정의할 때, 리턴타입은 명시하지 않아도 되지만, **파라미터 타입은 명시해야 한다.**
    - 라이브러리를 사용하는 외부의 유저에게 보여주기 위해서이다.
- 변수 이름에 타입이 포함되지 않도록 주의해야 한다.

## 클래스 함수는 생략 가능하다.

- **코틀린은 명령문이나 표현식이 메소드에 속할 필요가 없고, 메소드는 클래스에 속할 필요가 없다.**
- 스크립트로 실행될 때 코틀린은 JVM에서 실행하기 위해 **필수적으로 필요한 랩퍼(wrapper) 클래스와 메소/드를 생성한다.**

```kotlin
// standalone.ktx
fun nofluff() {
    println("nofluff called...")
    throw RuntimeException("oops") //5
}
println("not in a function, calling nofluff()")
try {
    nofluff() //9
} catch (ex: Exception) {
    val stackTrace = ex.getStackTrace()
    println(stackTrace[0])
    println(stackTrace[1])
}
```

```tsx
 kotlinc-jvm -script standalone.kts   
not in a function, calling nofluff()
nofluff called...
ch02.**Standalone**.nofluff(**standalone.kts**:5)
ch02.**Standalone**.<init>(**standalone.kts**:9)
```

코틀린은 조용히 nofluff() 함수를 Standalone이라는 동기화된 클래스의 메소드 안으로 넣었다. **클래스 이름은 파일 이름으로 추론된다.**

단독적으로 동작하는 코드는 클래스의 생성자 안으로 들어갔다.

- 작은 코드를 작성할 때 파일 안에 코드를 바로 작성하면 스크립트로 동작된다.
    
    클래스와 메소드를 만들기 위한 관례적인 코드가 필요 없다.
    

## try - catch는 선택사항이다.

코틀린은 checked이든 unchecked이든 상관없이 어떠한 예외도 처리하도록 강제하지 않는다. 만약에 try-catch문이 없는 함수를 호출했을 때 예외가 발생하면 자동으로 해당 함수를 호출한 함수 또는 호출한 코드로 전달된다.

호출한 코드나 함수에서 예외를 핸들링하지 않는다면 프로그램은 종료된다.

```tsx
println("Hello")
Thread.sleep(1000) //sleep() 메소드는 명시적 예외를 전달한다. try~catch를 강제하지 않는다.
println("World.")
```

- 예외처리를 위해서는 방어적 프로그래밍을 하는 것이 좋다.
- **개발자가 직접 다루지 않은 예외는 자동으로 호출한 코드로 전파된다**는 것을 기억할 것.

# 2-2. 현명한 경고

잠재적인 문제를 사전에 대처할 수 있도록 코틀린 컴파일러는 코드 안의 다양한 잠재적 문제들을 찾아낸다.

- ex) 함수나 메소드에 사용되지 않는 파라미터가 존재한다면 컴파일러가 경고를 준다.

```kotlin
fun compute(n: Int) = 0
println(compute(4))
```

```tsx
 kotlinc-jvm -script unused.kts 
0
unused.kts:3:13: warning: parameter 'n' is never used
fun compute(n: Int) = 0
            ^
```

> 경고(waring)를 오류처럼 다루는 것이 올바른 소프트웨어 개발 습관이다.
> 
- 코틀린에서 `-Werror` 옵션으로 경고를 오류처럼 다룰 수 있다.

```tsx
 kotlinc-jvm **-Werror** -script unused.kts
warning: parameter 'n' is never used (unused.kts:3:13)
error: warnings found and -Werror specified
unused.kts:3:13: warning: parameter 'n' is never used
fun compute(n: Int) = 0
            ^
```

# 2-3. var보다는 val

- val
    - 이뮤터블 변수(상수 또는 값) 정의, value의 val
    - Java의 final과 비슷
    - 재할당 불가능
- var
    - 뮤터블 변수
    - variable 의 var
- 함수형 프로그래밍에서 변수의 값을 변경하는 것이 터부시 된다.
    
    일반적으로 이뮤터블 변수를 사용하는 것이 선호된다.
    

다음 예제를 보자

```kotlin
var factor = 2
fun doubleIt(n: Int) = n * factor
factor = 0
println(doubleIt(2)) //실행결과를 예측하기 어렵다. 정답은 0이다.
```

**뮤터빌리티(mutablility, 변경가능성)는** 

- **코드를 추론하기 어렵게 만든다.**
- 오류가 발생할 가능성이 더 높다.
- 병렬화하기 더 어렵다.

- **var 대신에 val을 사용하려 노력해야 한다.**
- val도 주의해서 사용해야 한다.
    
    val은 **변수나 참조(reference)만 상수(constant)로 만든다.** **객체를 상수로 만드는 것은 불가능하**다. 그래서 val은 참조에 대한 이뮤터빌리티만을 보장해주고, 객체의 변화는 방지할 수 없다.
    

```kotlin
val message = StringBUilder("hello")
//message = StringBUilder("another") //오류발생. 참조는 변경 불가능
message.append("there") //가능. 객체내부의 값은 변경 가능
```

# 2-4. 향상된 동일성 체크

- `==` 연산자
    - 값을 비교
    - java `equals()`
    - 구조상의 동일성(structural equality)
    - 코틀린에서 `==` 연산자를 사용할 때, **null 체크를 먼저하고, equals() 메소드를 실행한다.**
- `===` 연산자
    - 참조 대상을 비교 (참조를 비교하고 두 비교대상이 같은 객체를 참조하는 경우 true를 반환)
    - java의 `==`
    - 참조상의 동일성(referential equality)

코틀린의 `==` 는 null 참조를 안전한게 다룬다. NPE가 발생하지 않는다. (아래 코드를 Java의 `equals()` 로 실행되었다면 런타임에서 NPE가 발생한다.)

```kotlin
println("hi" == "hi")   //true
println("hi" == "Hi")   //false
println(null == "hi")   //false
println("hi" == null)   //false
println(null == null)   //true
```

```jsx
// 결과가 항상 같은 값을 보여줄 것 같다면 경고를 통해서 쓸모없는 컨디션 체크를 하는 코드를 수정하라고 제안한다.
equality.kts:3:9: warning: condition 'null == "hi"' is always 'false'
println(null == "hi")   //false
        ^
equality.kts:4:9: warning: condition '"hi" == null' is always 'false'
println("hi" == null)   //false
        ^
equality.kts:5:9: warning: condition 'null == null' is always 'true'
println(null == null)   //true
```

# 2-5. 문자열 템플릿

- 큰따옴표(`”`) 문자열 안에 `$` 을 변수 앞에 붙여주면 변수가 문자열 안에 들어간다.
- 변수 하나 이상의 복잡한 명령문이라면 `${}` 로 감싸서 사용할 수 있다.
- `$` 심볼 뒤에 변수 이름이나 표현식이 없으면 문자로 취급된다. (또는 역슬래시(`\`)를 사용)

```kotlin
var price = 12.25
var taxRate = 0.08
var output = "The amount $price after tax comes to $${price * (1 + taxRate)}"
var disclaimer = "The amount is in US$, that's right in \$only"

println(output)
println(disclaimer)
```

```jsx
The amount 12.25 after tax comes to $13.23
The amount is in US$, that's right in $only
```

마찬가지로 `var`보다는 `val`을 사용해야 한다. 다음 코드를 보고 결과를 예측해보자

```kotlin
var factor = 2 //**var보다 val을 사용해야한다.**
fun doubleIt(number: Int) = number * factor //호출할 때 factor의 값으로 사용된다.
var message = "The factor is $factor" //message를 만들 시점의 factor의 값은 2
factor = 0

println(doubleIt(2))
println(message)
```

```jsx
0
The factor is 2
```

위 코드는 인지부하를 증가시키고 유지보수하기 어렵게 만들며 오류를 만들기 쉽다.

함수 `doubleIt()` 에 있는 변수 factor는 스코프 밖에서 바인딩된다. (렉시컬 스코프) 따라서 factor의 값은 함수가 호출된 시점에서 사용된다. 반면에 문자열 템플릿은 출력될 때가 아니고 message가 만들어질 때 사용된다.

**그러므로 factor 같은 변수를 가능한 한 var보다 val을 사용해야 한다.**

# 2-6. RAW 문자열

잡다한 기호 없이 멀티라인 문자열을 만드는 방법

- 시작과 끝에 큰따옴표 세 개를 이용해 raw 문자열을 사용할 수 있다.
- 이스케이프 문자 없이 아무 문자나 표현 가능
- 멀티라인 문자열도 ok

```kotlin
val name = "Solar"

val memo = """Dear $name, a quick reminder about the 
party we have scheduled next Tuesday at 
the 'Low Ceremony Cafe' at Noon. | Please plan to..."""

println(memo)
```

```kotlin
Dear Solar, a quick reminder about the 
party we have scheduled next Tuesday at 
the 'Low Ceremony Cafe' at Noon. | Please plan to...
```

멀티라인 문자열이 함수 안에 있으면 어떻게 될까?

if 안에 있다면?

```kotlin
fun createMemoFor(name: String): String {
    if (name == "Solar") {
        val memo = """Dear $name, a quick reminder about the 
            party we have scheduled next Tuesday at
            the 'Low Ceremony Cafe' at Noon. | Please plan to..."""
        return memo
    }

    return ""
}

println(createMemoFor("Solar"))
```

```kotlin
Dear Solar, a quick reminder about the 
            party we have scheduled next Tuesday at
            the 'Low Ceremony Cafe' at Noon. | Please plan to...
```

문자열에 들여쓰기가 포함되어 버린다.

- 둘 째 줄부터 모든 줄마다 시작점에 `수직선(|)`을 넣는다.
- `trimMargin()` 메소드를 사용해서 문자열 마진(margint)을 제거한다.
    - 수직선(|) 문자가 나올 때까지 공백을 제거하는 확장함수이다.
    - 시작점에 있는 수직선(|) 문자가 아닐 경우엔 아무런 영향도 주지 않는다.
    - 다른 문자열 구분자롤 사용하고 싶다면 첫번째 인자로 넣어주면 된다.
        
        ex) `~` 구분자로 사용 :  `trimMargin(~)` 
        

```kotlin
fun createMemoFor(name: String): String {
    if (name == "Solar") {
        val memo = """Dear $name, a quick reminder about the 
            |party we have scheduled next Tuesday at
            |the 'Low Ceremony Cafe' at Noon. | Please plan to..."""
        return memo.trimMargin()
    }

    return ""
}

println(createMemoFor("Solar"))
```

```kotlin
Dear Solar, a quick reminder about the 
party we have scheduled next Tuesday at
the 'Low Ceremony Cafe' at Noon. | Please plan to...
```

# 2-7. 표현식(expression)은 많이, 명령문(statement)은 적게

## 표현식과 명령문 중 어떤 것이 더 좋은가?

- 명령문은 아무것도 리턴하지 않을 뿐만 아니라, 부작용도 가지고 있다.
    - 부작용이란?
        
        상태가 변하고, 변수를 변하게 하고, 파일을 작성하고, 데이터베이스를 업데이트하고, 리보트 웹 서버에 데이터를 전송하고, 하드 드라이브를 오염시키는 것 등…
        
- 표현식은 결과를 리턴해주고, 어떤 상태도 변화시키지 않는다.

즉, **명령문 보다는 표현식이 좋다.**

차이를 확인해보기 위해서 Java 스타일로 코틀린 코드를 작성해보자

```kotlin
fun canVoteExpression(name: String, age: Int): String {
    **var** status: String //뮤터블 변수 var 사용
    if (age > 17) { //명령문 - 리턴값이 없다. 따라서 뮤터블 변수 status를 만들어서, 메소드 안에서 해당 변수를 수정해야 한다.
        status = "yes, please vote!"
    } else {
        status = "nope, please come back!"
    }

    return "$name, $status"
}
```

- if문을 명령문 상태로 사용한다.
- 명령문은 아무런 리턴값을 주지 않기 때문에 `canVoteExpression()`에서 결과를 얻기 위한 유일한 방법은 뮤터블 변수를 만들고, 메소드 안에서 해당 변수를 수정하는 것 뿐이다.

**코틀린에서 if는 표현식이다.** 코틀린 스타일로 수정해보자

```kotlin
fun canVoteStatement(name: String, age: Int): String {
    **val** status = if (age > 17) "yes, please vote!" else "nope, please come back!" //표현식 - if를 호출하고, 결과를 사용할 수 있따.
    return "$name, $status"
}
```

- if를 호출하고, 그 결과를 사용할 수 있다.
- `var`가 아닌 `val` 을 사용할 수 있다.
- `status`에 타입추론을 사용할 수 있다.

⇒ 코드는 덜 지저분하고, 오류도 덜 발생한다.

### 코틀린은 try-catch도 표현식으로 취급한다.

- 예외가 발생하지 않는 경우 : try식 안의 마지막 부분이 결과가 된다.
- 예외가 발생하는 경우 : catch 식의 마지막 부분이 결과가 된다.

```kotlin
fun tryExpression(blowup: Boolean): Int {
    return try { //try에서 줄바꿈하면 오류남...
        if (blowup) {
            throw RuntimeException("fail!!!!!")
        }
        2
    } catch (e: Exception) {
        4
    } finally {

    }
}

println(tryExpression(false)) //2
println(tryExpression(true)) //4
```

### 코틀린은 할당을 표현식으로 취급하지 않는다.

- 자바에서는 할당을 표현식으로 취급하지만 코틀린은 그러지 않다.

아래 코드는 코틀린에서 실행되지 않는다.

```kotlin
var a = 1
var b = 2
var c = 3

a = b = c //오류!!
```

위 식이 표현식으로 취급되지 않는 이유?

코틀링니 델리게이션(delegate, 위임)을 통해 변수를 get하거나 set하도록 허용하기 때문이다. 만약에 대입연산자(`=`)이 표현식으로 다뤄졌따면 할당 체이닝은 예상할 수 없고, 복잡한 행동을 하면서 혼란을 주고 오류를 불러올 것이다.