### PR TITLE
[다재다능 코틀린 프로그래밍] ch03 - 함수를 사용하자

### DIFF
--- a/kotlin-programming/src/main/kotlin/ch03/caveat.kts
+++ b/kotlin-programming/src/main/kotlin/ch03/caveat.kts
@@ -1,0 +1,11 @@
+package ch03
+
+fun caveat1() = 2
+fun caveat2() = { 2 }
+fun caveat3(factor: Int) = { n: Int -> n * factor }
+
+println(caveat1())
+println(caveat2())
+println(caveat2()())
+println(caveat3(2))
+println(caveat3(2)(3))

--- a/kotlin-programming/src/main/kotlin/ch03/defaultCompute.kts
+++ b/kotlin-programming/src/main/kotlin/ch03/defaultCompute.kts
@@ -1,0 +1,6 @@
+package ch03
+
+fun greet(name: String, message: String = "Hi ${name.length}") = "$message $name"
+
+println(greet("Solar"))
+println(greet("Solar", "Developer"))

--- a/kotlin-programming/src/main/kotlin/ch03/destructuring.kts
+++ b/kotlin-programming/src/main/kotlin/ch03/destructuring.kts
@@ -1,0 +1,38 @@
+package ch03
+
+fun getFullName() = Triple("Solar", "Rachel", "Anne")
+
+fun destructuring1() {
+    val result = getFullName()
+    val first = result.first
+    val middle = result.second
+    val last = result.third
+
+    println("$first $middle $last")
+}
+
+fun destructuring2() {
+    val (first, middle, last) = getFullName()
+    println("$first $middle $last")
+}
+
+fun destructuring3() {
+    val (first, _, last) = getFullName()
+    println("$first $last")
+}
+
+fun destructuring4() {
+    val (_, _, last) = getFullName()
+    println(last)
+}
+
+fun destructuring5() {
+    val (_, middle) = getFullName()
+    println(middle)
+}
+
+destructuring1()
+destructuring2()
+destructuring3()
+destructuring4()
+destructuring5()

--- a/kotlin-programming/src/main/kotlin/ch03/kiss.kts
+++ b/kotlin-programming/src/main/kotlin/ch03/kiss.kts
@@ -1,0 +1,10 @@
+package ch03
+
+fun greet() = "Hello" //리턴타입을 추론해주기 때문에 리턴타입을 생략할 수 있다.
+println(greet())
+
+//리턴타입 추론은 컴파일할 때 진행된다.
+//Int형 변수에 greet() 결과를 할당하려고 하면 컴파일 오류가 발생한다.
+//val message: Int = greet() //Type mismatch: inferred type is String but Int was expected
+
+

--- a/kotlin-programming/src/main/kotlin/ch03/mixVararg.kts
+++ b/kotlin-programming/src/main/kotlin/ch03/mixVararg.kts
@@ -1,0 +1,7 @@
+package ch03
+
+fun greetMany(message: String, vararg names: String) {
+    println("$message ${names.joinToString(", ")}")
+}
+
+greetMany("Hello", "Rinjyu", "Kotlin")

--- a/kotlin-programming/src/main/kotlin/ch03/multiLineFunction.kts
+++ b/kotlin-programming/src/main/kotlin/ch03/multiLineFunction.kts
@@ -1,0 +1,12 @@
+package ch03
+
+fun max(numbers: IntArray): Int {
+    var large = Int.MIN_VALUE
+    for (number in numbers) {
+        large = if (number > large) number else large
+    }
+
+    return large
+}
+
+println(max(intArrayOf(1, 5, 2, 12, 7, 3)))

--- a/kotlin-programming/src/main/kotlin/ch03/namedArguments.kts
+++ b/kotlin-programming/src/main/kotlin/ch03/namedArguments.kts
@@ -1,0 +1,11 @@
+package ch03
+
+fun createPerson(name: String, age: Int = 1, height: Int, weight: Int) {
+    println("$name $age $height $weight")
+}
+
+createPerson("Solar", 20, 170, 40)
+createPerson("Solar", age = 20, weight = 40, height = 170)
+createPerson("Solar", 20, weight = 40, height = 170)
+createPerson(weight = 40, height = 170, name = "Solar") //age는 기본값이 있어서 생략 가능
+createPerson("Solar", weight = 40, height = 170)

--- a/kotlin-programming/src/main/kotlin/ch03/passingArguments.kts
+++ b/kotlin-programming/src/main/kotlin/ch03/passingArguments.kts
@@ -1,0 +1,5 @@
+package ch03
+
+fun greet(name: String): String = "Hello $name"
+
+println(greet("Solar"))

--- a/kotlin-programming/src/main/kotlin/ch03/specifyUnit.kts
+++ b/kotlin-programming/src/main/kotlin/ch03/specifyUnit.kts
@@ -1,0 +1,7 @@
+package ch03
+
+fun sayHello() = println("Well, hello")
+//val message: String = sayHello() //ERROR : Type mismatch: inferred type is Unit but String was expected
+val message2: Unit = sayHello()
+
+println("The result of sayHello is $message2")

--- a/kotlin-programming/src/main/kotlin/ch03/vararg.kts
+++ b/kotlin-programming/src/main/kotlin/ch03/vararg.kts
@@ -1,0 +1,19 @@
+package ch03
+
+fun max(vararg numbers: Int): Int {
+    var large = Int.MIN_VALUE
+    for (number in numbers) {
+        large = if (number > large) number else large
+    }
+
+    return large
+}
+
+println(max(1, 5, 2))
+println(max(1, 5, 2, 12, 7 , 3))
+
+val values = intArrayOf(1, 20, 5)
+println(max(values[0], values[1], values[2]))
+//println(max(values)) //ERROR - 배열이나 리스트를 직접 넘길 수 없다.
+println(max(*values)) //스프레드 연산자 (*)를 이용해서 넘길 수 있다.
+println(max(*listOf(1, 4, 18, 12).toIntArray())) //리스트를 배열로 변환해서 스프레드 연산자를 적용할 수 있다.


### PR DESCRIPTION
# CH03. 함수를 사용하자

- 코틀린은 무조건 클래스를 사용하라고 강요하지 않는다.
    
    재사용이 가능한 가장 작은 단위가 클래스인 Java와는 달리, **코틀린에서는 클래스는 물론 단독 함수(standalone function)까지 모두 재사용이 가능하다.**
    
- 단독 함수를 만들고 코드 안의 메소드나 함수에서 필요할 때마다 사용할 수 있다.

단독 함수 특징

- 코틀린에서 재사용 가능한 탑 레벨 단독함수를 만들면 클래스에서 시간과 노력을 낭비하지 않는다.
    - 클래스 안의 정적 메소드로 만들 필요가 없다. 즉, 언어의 제약 때문에 객체지향인척 할 필요가 없다는 뜻
    - 글로벌 탑레벨 함수를 만들 수 있다.
    - 함수는 탑레벨에 존재하거나 패키지 안에 직접 존재할 수 있다.
- 함수는 클래스의 메소드보다 뛰어난 능력을 가지고 있다.

함수 특징

- 함수가 특정 타입의 파라미터를 사용하도록 정해야 한다.
- 단일 표현식 함수(single-expression function)에 대한 리턴 유형을 유추하도록 요청할 수 있다.
- 함수를 호출할 때, 모든 파라미터를 전달하지 않고 기본 파라미터를 전달할 수 있다.
    
    ⇒ 이런 특징을 이용해서 함수와 메소드를 쉽게 확장할 수 있다.
    
- 아규먼트에 이름을 만들 수 있다.
- 함수에 가변 아규먼트를 컴파일 안정성 저해 없이 넘길 수 있다.
- 코틀린은 **구조분해(destructuring)** 기능을 가지고 있어서 객체에서 속성을 독립 변수(standalone variable)로 뽑아낼 수 있다.

이번 챕터에서 다음을 알아볼 것이다.

- 전역 함수와 단독(standalone) 함수를 사용하는 법,
- 함수가 어떻게 표현식으로 취급되는지
- 기본 아규먼트, 명시적(named) 아규먼트, 가변 아규먼트 정의, 스프레드 연산자, 구조분해

# 3-1. 함수 생성

## 키스(KISS) 함수

함수를 정의할 때 “단순하게 해, 멍청아!(Keep It Simple, Stupid, KISS 원칙)”을 준수한다.

가장 짧은 함수를 실행해보자

```kotlin
fun greet() = "Hello" //리턴타입을 추론해주기 때문에 리턴타입을 생략할 수 있다.
println(greet())
```

- 함수 정의는 `fun` 으로 시작
- `fun 함수이름(파라미터) = 단일표현함수`
- `fun 함수이름(파라미터): 리턴타입 = { ... return 반환값}`
- 함수가 단일표현함수라면 바디를 `{}` 로 만드는 대신 함수 정의부와 함수 바디를 `=`로 구분할 수 있다.
- 짧은 함수의 리턴타입은 추론이 가능하다.
- `{}` 블록 바디가 없는 단일표현함수에서는 return 키워드를 사용할 수 없다.

## 리턴타입과 타입 추론

코틀린이 `{}` 블록 바디가 없는 함수에 대해 타입 추론을 해준다. **리턴타입 추론은 컴파일할 때 진행된다.**

```kotlin
//Int형 변수에 greet() 결과를 할당하려고 하면 컴파일 오류가 발생한다.
val message: Int = greet() //Type mismatch: inferred type is String but Int was expected
```

- 타입추론은 내부 API에서 사용가능하고, 단일표현 함수가 `=` 로 정의도니 경우 사용할 수 있다.
- **하지만 함수가 외부에서 사용되거나 복잡하다면 리턴타입을 지정해주도록 하자.**

## 모든 함수는 표현식이다. - Unit

함수는 명령문보다는 표현식으로 취급되어야 한다. 함수가 아무것도 리턴하지 않는다면 어떻게 될까?

코틀린은 **Unit**이라는 특별한 타입을 사용한다.

- Java의 void와 대응된다.
- 리턴할 게 없는 경우 Unit을 사용할 수 있다.
- 함수에 리턴이 없으면 Unit 타입을 리턴 타입으로 추론한다.

그래서 모든 함수는 표현식으로 취급될 수 있고, 그 결과들은 변수에 할당되거나 추후 프로세스를 위해서 사용될 수 있다.

sayHello()의 결과인 Unit 타입을 String 타입 변수에 할당하면 에러가 나는 것을 알 수 있다.

```kotlin
fun sayHello() = println("Well, hello")
val message: String = sayHello() //ERROR : Type mismatch: inferred type is Unit but String was expected
```

타입추론 사용 대신에 리턴 타입으로 Unit을 지정해줄 수도 있다.

```kotlin
fun sayHello(): **Unit** = println("Well, hello")
val message: Unit = sayHello()

println("The result of sayHello is $message")
```

```kotlin
Well, hello
The result of sayHello is kotlin.Unit
```

## 파라미터 정의하기

- 코틀린은 함수나 메소드에 파라미터의 타입을 명시하도록 했다.
- `candidate(후보): Type` 형태의 문법을 사용
- 파라미터에 `val`이나 `var`을 사용하지 않는다. 무조건 `val` 이다.
- **함수나 메소드에서 파라미터의 값을 변화시키면 컴파일 오류가 발생한다.**

```kotlin
fun greet(name: String): String = "Hello $name"
println(greet("Solar")) //Hello Solar
```

## 블록바디로 만든 함수

- 블록 바디(`{}`)를 이용해서 함수를 정의하면 항상 리턴타입을 정의해줘야 한다.
- 정의하지 않으면 리턴타입은 Unit으로 추론된다.
- `=` 와 `{}` 를 함께 사용하지 말자

```kotlin
fun max(numbers: IntArray): Int {
    var large = Int.MIN_VALUE
    for (number in numbers) {
        large = if (number > large) number else large
    }

    **return** large
}

println(max(intArrayOf(1, 5, 2, 12, 7, 13))) //12
```

리턴타입을 생략하고 `=` 을 사용해 단일표현식 대신 블록 바디를 사용하면 어떻게 될까?

```kotlin
fun caveat2() = { 2 }
```

- 코틀린은 코드 블록 안으로 들어가서 리터타입을 추론하지 않는다.
- 이 경우 코틀린은 블록을 람다표현식이나 익명함수(anonymous function)으로 취급한다.

`=` 을 블록과 함께 사용하고 리턴타입을 명시하지 않은 경우를 보자

```kotlin
fun caveat1() = 2
fun caveat2() = { 2 }
fun caveat3(factor: Int) = { n: Int -> n * factor }

println(caveat1()) //2
println(caveat2()) //() -> kotlin.Int //람다표현식
println(caveat2()()) //2 //람다표현식 실행결과
println(caveat3(2)) //(kotlin.Int) -> kotlin.Int
println(caveat3(2)(3)) //6 //factor : 2, n : 3
```

# 3-2. 기본 인자와 명시적 인자

기본 아규먼트 기능을 쓰면 바이너리가 변경되므로 컴파일을 다시 해야 한다.

## 기본 아규먼트를 통한 함수 변경

아래 greet() 함수는 “Hello”라고 하드코딩 되어있다. 호출하는 곳에서 선택할 수 있도록 유연성을 제공하고 싶다면 어떻게 할까?

```kotlin
fun greet(name: String) = "Hello $name"
```

Java에서는 오버로딩을 사용했다. 이 방식은 코드의 중복이 발생한다.

코틀린은 기본 아규먼트를 이용해서 이런 문제를 쉽게 해결한다.

- 기본 아규먼트
    - 기본값을 가지는 파라미터
    - 함수를 호출하는 쪽에서 해당 파라미터의 값을 전달하지 않는다면 기본값이 사용된다.
    - `(이름: 타입) = 기본값`

기본값을 가지는 파라미터를 추가해보자

```kotlin
fun greet(name: String, message: String = "Hello") = "$message $name"

println(greet("Solar")) //Hello Solar
println(greet("Solar", "Developer")) //Devloper Solar
```

- 기본 아규먼트를 효과적으로 만들기 위해서는 맨 마지막에 사용하는 것이 좋다.
- 람다표현식이 파라미터로 들어오는 경우는 람다표현식 앞에서 사용하면 된다.
- 기본 아규먼트는 값(리터럴)일 필요가 없다. 표현식이 올 수도 있따.
- 앞서 전달받은 파라미터를 처리해서 기본값을 설정할 수도 있다.

```kotlin
fun greet(name: String, message: String = "Hi ${name.length}") = "$message $name" //여기에서는 name과 message 순서를 바꾸면 컴파일 오류가 난다.

println(greet("Solar")) //Hi 5 Solar
println(greet("Solar", "Developer")) //Developer Solar
```

## 명시적 아규먼트(Named Argument)를 이용한 가독성 향상

함수를 호출하는 곳에서는 아규먼트들이 뭘 의미하는지 추측하기 어렵다. 의미를 파악하기 위해서는 함수 정의 부분을 봐야한다.

- 명시적 아규먼트는 순서와 상관없이 사용할 수 있다.
- 함수의 변경으로 인한 파라미터 추가시 함수에 발생할 수 있는 잠재적인 오류의 가능성들을 제거해준다.

```kotlin
fun createPerson(name: String, age: Int = 1, height: Int, weight: Int) {
    println("$name $age $height $weight")
}

createPerson("Solar", 20, 170, 40)
createPerson("Solar", age = 20, weight = 40, height = 170)
createPerson("Solar", 20, weight = 40, height = 170)
createPerson(weight = 40, height = 170, name = "Solar") //age는 기본값이 있어서 생략 가능
createPerson("Solar", weight = 40, height = 170)
```

# 3-3. 다중인자와 스프레드

- 다중인자(vararg) 기능은 함수가 한 번에 여러 개의 인자를 받을 때 타입 안정성을 제공해주는 기능이다.

## 여러 개의 인자

기존에 배열을 인자로 받았던 max()함수를 호출 시 좀 더 유연하게 사용할 수 있도록 변경해보자

- numbers가 `vararg` 키워드로 선언되었다.
- 파라미터 타입이 `IntArray`에서 `Int` 로 변경
- **실제 파라미터 numbers의 타입은 배열(array)이다.**
- `vararg` 키워드가 파라미터로 특정 타입의 배열이 들어갈 수도 있다는 점을 알려준 것이다.

```kotlin
fun max(**vararg** numbers: **Int**): Int {
    var large = Int.MIN_VALUE
    for (number in numbers) {
        large = if (number > large) number else large
    }

    return large
}

println(max(1, 5, 2))
println(max(1, 5, 2, 12, 7 , 3))
```

### vararg 위치 권장사항

- vararg는 마지막에 두어서 호출 시 명시적 인자를 필수적으로 사용할 필요가 없도록 만들자
- 마지막 파라미터가 람다표현식일 경우 마지막 바로 전에 둔다.

> 이미 배열이 있다면 어떨까? → 스프레드 연산자를 사용하면 된다.
> 

## 스프레드 연산자

- 함수가 다중 인자를 받을 수 있도록 정의되어 있지만 **배열이나 리스트를 직접 받을 수는 없다.**
- 이럴때 **스프레드 연산자(`*`)**가 필요하다.
- 리스트에 직접 스프레드 연산자를 적용할 수 는 없다. 대신 리스트를 배열로 변환해서 적용할 수 있다.
- `List<T>` 의 메소드인 `to...Array()` 메소드를 이용해서 적절한 타입의 배열로 변환한 후 사용하면 된다.

```kotlin
val values = intArrayOf(1, 20, 5)
println(max(values[0], values[1], values[2]))
//println(max(values)) //ERROR - 배열이나 리스트를 직접 넘길 수 없다.
println(max(*values)) //스프레드 연산자 (*)를 이용해서 넘길 수 있다.
println(max(*listOf(1, 4, 18, 12).toIntArray())) //리스트를 배열로 변환해서 스프레드 연산자를 적용할 수 있다.
```

# 3-4. 구조분해

- 구조화 : 다른 변수의 값으로 객체를 만드는 것
- 구조분해(Destructuring) : 객체에서 값을 추출해 변수로 넣는 작업
- 코틀린의 구조분해는 (속성의 이름이 아닌) 속성의 위치를 기반으로 진행된다.

함수를 호출해서 결과를 받은 후 3개의 변수에 할당하는 전통적인 지루한 코드를 먼저 보자

```kotlin
fun getFullName() = Triple("Solar", "Rachel", "Anne")

fun destructuring1() {
    val result = getFullName()
    val first = result.first
    val middle = result.second
    val last = result.third

    println("$first $middle $last") //Solar Rachel Anne
}
```

구조분해를 사용해서 다음과 같이 바꿀 수 있다.

```kotlin
fun destructuring2() {
    val (first, middle, last) = getFullName()
    println("$first $middle $last") //Solar Rachel Anne
}
```

이게 가능한 이유는 Triple 클래스가 구조변화를 위한 특별한 메소드를 가지고 있기 때문이다. (더 자세한 사항은 책의 뒷부분에서..)

- **객체의 속성들이 구조분해되는 순서는 객체의 컨스트럭터가 객체를 초기화할 떄 속성을 만드는 순서와 동일하다.**
- **필요없는 속성은 언더스코어(`_`)를 이용해 해당 속성을 스킵할 수 있다.**

```kotlin
fun destructuring3() {
    val (first, _, last) = getFullName()
    println("$first $last") //Solar Anne
}

fun destructuring4() {
    val (_, _, last) = getFullName()
    println(last) //Anne
}

fun destructuring5() {
    val (_, middle) = getFullName()
    println(middle) //Rachel
}
```