### PR TITLE
[다재다능 코틀린 프로그래밍] ch06 - 오류를 예방하는 타입 안정성

### DIFF
--- a/kotlin-programming/.idea/git_toolbox_prj.xml
+++ b/kotlin-programming/.idea/git_toolbox_prj.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GitToolBoxProjectSettings">
+    <option name="commitMessageIssueKeyValidationOverride">
+      <BoolValueOverride>
+        <option name="enabled" value="true" />
+      </BoolValueOverride>
+    </option>
+    <option name="commitMessageValidationConfigOverride">
+      <CommitMessageValidationOverride>
+        <option name="enabled" value="true" />
+      </CommitMessageValidationOverride>
+    </option>
+  </component>
+</project>

--- a/kotlin-programming/src/main/kotlin/ch04/activity.kts
+++ b/kotlin-programming/src/main/kotlin/ch04/activity.kts
@@ -3,7 +3,7 @@ fun whatToDo(dayOfWeek: Any) = when (dayOfWeek) {
     in listOf("Monday", "Tuesday", "Wednesday", "Thursday") -> "Work hard"
     in 2..4 -> "Work hard"
     "Friday" -> "Party"
-    is String -> "What?"
+    is String -> "What, you provided a string of length ${dayOfWeek.length}" //스마트캐스
     else -> "No Clue"
 }
 

--- a/kotlin-programming/src/main/kotlin/ch06/closeable.kts
+++ b/kotlin-programming/src/main/kotlin/ch06/closeable.kts
@@ -1,0 +1,11 @@
+// 파라미터 타입 제한
+// close() 메서드가 있는 AutoCloseable 인터페이스를 구현한 타입만 받도록 제한
+// 이 방식으로는 한가지 조건만 넣을 수 있다. 여러 조건을 넣으려면 where을 사용해야하다.
+fun <T: AutoCloseable> useAndClose(input: T) {
+    input.close()
+}
+
+val writer = java.io.StringWriter()
+writer.append("hello ")
+useAndClose(writer)
+println(writer)

--- a/kotlin-programming/src/main/kotlin/ch06/copy.kts
+++ b/kotlin-programming/src/main/kotlin/ch06/copy.kts
@@ -1,0 +1,20 @@
+open class Fruit
+class Banana: Fruit()
+
+// 타입제한
+fun copyFromTo(from: Array<Fruit>, to: Array<Fruit>) {
+    for (i in 0 until from.size) {
+        to[i] = from[i]
+    }
+}
+
+//1.
+val fruitsBasket1 = Array<Fruit>(3) { _ -> Fruit() }
+val fruitsBasket2 = Array<Fruit>(3) { _ -> Fruit() }
+copyFromTo(fruitsBasket1, fruitsBasket2) //OK
+
+//2.
+val fruitsBasket = Array<Fruit>(3) { _ -> Fruit() }
+val bananaBasket = Array<Banana>(3) { _ -> Banana() }
+//copyFromTo(bananaBasket, fruitsBasket) //ERROR - Type mismatch
+

--- a/kotlin-programming/src/main/kotlin/ch06/copyInerr.kts
+++ b/kotlin-programming/src/main/kotlin/ch06/copyInerr.kts
@@ -1,0 +1,17 @@
+open class Fruit
+class Banana : Fruit()
+
+// 반공변성 사용하기 - in
+fun copyFromTo(from: Array<out Fruit>, to: Array<in Fruit>) {
+    for (i in 0 until from.size) {
+        to[i] = from[i]
+    }
+}
+
+val fruitsBasket1 = Array<Fruit>(3) { _ -> Fruit() }
+val fruitsBasket2 = Array<Fruit>(3) { _ -> Fruit() }
+copyFromTo(fruitsBasket1, fruitsBasket2) //OK
+
+val things = Array<Any>(3) { _ -> Fruit() } //부모타입의 Any
+val bananaBasket = Array<Banana>(3) { _ -> Banana() }
+copyFromTo(bananaBasket, things) //OK

--- a/kotlin-programming/src/main/kotlin/ch06/copyOut.kts
+++ b/kotlin-programming/src/main/kotlin/ch06/copyOut.kts
@@ -1,0 +1,20 @@
+open class Fruit
+class Banana : Fruit()
+
+// 공변성 사용하기 - out
+fun copyFromTo(from: Array<out Fruit>, to: Array<Fruit>) {
+    for (i in 0 until from.size) {
+        to[i] = from[i]
+        //아래와 같이 from data에 쓰기 작업을 하는 코드가 있다면 컴파일에러가 난다.
+//        from[i] = Fruit()
+//        from.set(i, to[i])
+    }
+}
+
+val fruitsBasket1 = Array<Fruit>(3) { _ -> Fruit() }
+val fruitsBasket2 = Array<Fruit>(3) { _ -> Fruit() }
+copyFromTo(fruitsBasket1, fruitsBasket2) //OK
+
+val fruitsBasket = Array<Fruit>(3) { _ -> Fruit() }
+val bananaBasket = Array<Banana>(3) { _ -> Banana() }
+copyFromTo(bananaBasket, fruitsBasket) //OK

--- a/kotlin-programming/src/main/kotlin/ch06/equals.kts
+++ b/kotlin-programming/src/main/kotlin/ch06/equals.kts
@@ -1,0 +1,10 @@
+class Animal {
+    override operator fun equals(other: Any?) = other is Animal
+}
+
+val greet: Any = "hello"
+val odie: Any = Animal()
+val toto: Any = Animal()
+
+println(odie == greet)
+println(odie == toto) //equals() 메소드를 == 연산자로 사용할 수 있다.

--- a/kotlin-programming/src/main/kotlin/ch06/nonull.kts
+++ b/kotlin-programming/src/main/kotlin/ch06/nonull.kts
@@ -1,0 +1,11 @@
+fun nickName(name: String): String {
+    if (name == "Solar") {
+        return "Holar"
+    }
+//    return null // compile error - Null can not be a value of a non-null type String
+    return "HaHa"
+}
+
+println("Nickname for Solar is ${nickName("Solar")}")
+println("Nickname for Kolar is ${nickName("Kolar")}")
+//println(nickName(null)) // compile error - Null can not be a value of a non-null type String

--- a/kotlin-programming/src/main/kotlin/ch06/null.kts
+++ b/kotlin-programming/src/main/kotlin/ch06/null.kts
@@ -1,0 +1,11 @@
+fun nickName(name: String?): String? {
+    if (name != null) {
+        return name.reversed()
+    }
+
+    return null
+}
+
+println("Nickname for Solar is ${nickName("Solar")}")
+println("Nickname for Rachel is ${nickName("Rachel")}")
+println("Nickname for null is ${nickName(null)}")

--- a/kotlin-programming/src/main/kotlin/ch06/reifiedType.kts
+++ b/kotlin-programming/src/main/kotlin/ch06/reifiedType.kts
@@ -1,0 +1,31 @@
+abstract class Book(val name: String)
+class Fiction(name: String): Book(name)
+class NonFiction(name: String): Book(name)
+
+val books: List<Book> = listOf(
+    Fiction("Moby Dick"), NonFiction("Learn to Code"), Fiction("LOTR")
+)
+
+// 1. Java에서 작성하던 방식
+// 원하는 객체의 타입을 파라미터로 던진다. - ofClass: Class<T>
+fun <T> findFirst(books: List<Book>, ofClass: Class<T>): T {
+    val selected = books.filter { book -> ofClass.isInstance(book)} //타입체크
+    if (selected.size == 0) {
+        throw java.lang.RuntimeException("Not Found")
+    }
+    return ofClass.cast(selected[0]) //타입 캐스팅
+}
+
+println(findFirst(books, NonFiction::class.java).name) //Learn to Code
+
+// 2. 코틀린에서 구체화된(reified) 타입 파라미터를 사용하기
+inline fun <reified  T> findFirst(books: List<Book>): T {
+    val selected = books.filter { book -> book is T } //T를 타입 체크로 사용
+    if (selected.size == 0) {
+        throw RuntimeException("Not Found")
+    }
+
+    return selected[0] as T //T를 타입 캐스팅용으로 사용
+}
+
+println(findFirst<Fiction>(books).name) //Moby Dick

--- a/kotlin-programming/src/main/kotlin/ch06/returnnull.kts
+++ b/kotlin-programming/src/main/kotlin/ch06/returnnull.kts
@@ -1,0 +1,27 @@
+fun nickName(name: String?): String? {
+    if (name == "Solar") {
+        return "Holar"
+    }
+
+    //1. 지저분한 null 체크 -> 세이프 콜 연산자를 이용해서 깨끗하게 고쳐보자
+//    if (name != null) {
+//        return name.reversed()
+//    }
+//    return null
+
+    //2. 세이프콜 - ?
+    //세이프콜 연산자로 연결할 수 있다.
+    //타깃이 null일 경우에 null을 리턴한다.
+//    return name?.reversed()?.toUpperCase();
+
+    //3. 엘비스 연산자 - ?:
+    //참조가 null이면 null이 아닌 값을 리턴할 수 있다.
+//    return name?.reversed()?.toUpperCase() ?: "Joker";
+
+    //4. 확정 연산자 - !!
+    return name!!.reversed().toUpperCase() //no-error but BAD CODE
+}
+
+println("Nickname for Solar is ${nickName("Solar")}")
+println("Nickname for Kolar is ${nickName("Kolar")}")
+println(nickName(null))

--- a/kotlin-programming/src/main/kotlin/ch06/smartCast.kts
+++ b/kotlin-programming/src/main/kotlin/ch06/smartCast.kts
@@ -1,0 +1,12 @@
+class Animal(val age: Int) {
+    override operator fun equals(other: Any?):Boolean {
+        return if (other is Animal) age == other.age else false
+    }
+}
+
+var odie = Animal(2)
+var toto = Animal(2)
+var butch = Animal(3)
+
+println(odie == toto)
+println(odie == butch)

--- a/kotlin-programming/src/main/kotlin/ch06/star.kts
+++ b/kotlin-programming/src/main/kotlin/ch06/star.kts
@@ -1,0 +1,9 @@
+// 스타 프로젝션
+fun printValue(values: Array<*>) {
+    for (value in values) {
+        println(value)
+    }
+//    values[0] = values[1] // error -  Array<*> 를 파라미터로 받았기 때문에 함수 내에서 어떠한 변경도 허용되지 않는다.
+}
+
+printValue(arrayOf(1, 2))

--- a/kotlin-programming/src/main/kotlin/ch06/typeInvariance.kts
+++ b/kotlin-programming/src/main/kotlin/ch06/typeInvariance.kts
@@ -1,0 +1,16 @@
+open class Fruit
+class Banana: Fruit()
+class Orange: Fruit()
+
+fun receiveFruitsArray(fruits: Array<Fruit>) {
+    println("Number of fruits : ${fruits.size}")
+}
+val oranges: Array<Orange> = arrayOf()
+//receiveFruitsArray(oranges) // ERROR - type mismatch
+
+fun receiveFruitsList(fruits: List<Fruit>) {
+    println("Number of fruits: ${fruits.size}")
+}
+
+val bananas: List<Banana> = listOf()
+receiveFruitsList(bananas) //OK

--- a/kotlin-programming/src/main/kotlin/ch06/unsafeCast.kts
+++ b/kotlin-programming/src/main/kotlin/ch06/unsafeCast.kts
@@ -1,0 +1,10 @@
+fun fetchMessage(id: Int): Any =
+    if (id == 1) "Record found" else StringBuilder("data not found")
+
+//for (id in 1..2) {
+//    println("Message length: ${(fetchMessage(id) as String).length}") //unsafety - RUNTIME ERROR
+//}
+
+for (id in 1..2) {
+    println("Message length: ${(fetchMessage(id) as? String)?.length ?: "---"}") //safety
+}

--- a/kotlin-programming/src/main/kotlin/ch06/where.kts
+++ b/kotlin-programming/src/main/kotlin/ch06/where.kts
@@ -1,0 +1,12 @@
+// where을 사용한 파라미터 타입 제한
+// 여러 조건을 넣을 수 있다.
+// close() 메서드가 있는 AutoCloseable, Appendable 인터페이스를 구현한 타입만 받도록 제한
+fun <T> useAndClose(input: T) where T : AutoCloseable, T : Appendable {
+    input.append("there")
+    input.close()
+}
+
+val writer = java.io.StringWriter()
+writer.append("hello ")
+useAndClose(writer)
+println(writer)


### PR DESCRIPTION
# CH06. 오류를 예방하는 타입 안정성

코틀린은 향상된 null 체크, 스마트 타입 캐스팅, 유연한 타입 ㅊ체킹을 이용해서 개발자들의 코드를 더욱 타입 안정적이면서도 적은 오류를 만들도록 한다.

코틀린의 디자인 바이 컨트랙트 접근방식

- 함수나 메소드가 null을 받거나 리턴할 수 있는지 명확하게 표현할 수 있고, 그 시점도 알 수 있따.
- 만약 참조가 null이 될 수 있다면 참조하고 있는 객체의 속성이나 메소드를 사용할 땐 언제나 null 체크를 하도록 강제한다.
- 컴파일 타임에 체크가 이루어지고 바이트코드에는 아무 것도 추가되지 않는다.

# 6-1. Any와 Nothing 클래스

- 코틀린의 모든 클래스는 `Any` 클래스를 상속 받는다.
    - Java의 Object에 대응되는 클래스
    - `Any` 클래스 어떤 클래스에서도 사용 가능하고 유용한 메소드들을 많이 가지고 있다.
- 코틀린의 `Nothing` 클래스
    - `Nothing` 클래스는 함수가 아무것도 리턴하지 않을 경우 리턴되는 클래스
    - 메소드가 하나 이상의 브랜치에서 아무것도 리턴하지 않을 경우 타입 체크를 한다면 `Nothing` 클래스가 있어야 유용
        
        > 어떻게 유용하다는 거지?
        > 
    - Java에서 대응되는 것이 없음

## 베이스 클래스 Any

`Any` 클래스는 개발자에게 최대한 유연성을 제공한다. 함수가 여러 타입의 객체를 파라미터로 받는다면, 그 파라미터의 타입을 `Any`로 설정할 수 있고, 함수가 여러 타입을 리턴한다면 `Any`를 리턴하면 된다. **하지만 `Any`
 클래스는 아주 제한적으로 사용해야만 한다.**

- `equals()`, `toString()`과 같이 코틀린의 모든 타입에 공통으로 적용되는 메소드를 만들기 위해 존재
- 확장함수를 통해 특별한 메소드들을 제공
    - 확장함수 예 : to(), let(), run(), apply(), also() (*12-5. Any 객체를 이용한 자연스러운 코드)
- 내부DSL을 만들 때 유용 (*Ch13. 내부 DSL 만들기)

## Nothing은 void보다 강력하다

- 코틀린에서는 표현식이 리턴을 하지 않을때 `void` 대신 `Unit`을 사용한다.
- **리턴이라는 행위 자체를 하지 않을땐 `Nothing`을 리턴한다.**
    
    즉, `Nothing` 클래스는 **인스턴스가 없고, 값이나 결과가 영원히 존재하지 않을 것**이라는 걸 나타냅니다.
    
    > 어떤 경우?
    > 
- `Nothing` 은 모든 클래스로 대체할 수 있다.
- 예외는 `Nothing` 타입을 대표한다.
    
    아래 코드를 살펴보자. if문은 Double을 else는 예외를 던진다. 이 경우 컴파일러는 if문의 리턴타입이 Double이라고 정의할 수 있다.
    
    ```kotlin
    fun computeSqrt(n: Double): Double {
    	if(n >= 0) {
    		return Math.sqrt(n)
    	} else {
    		throw RuntimeException("No negative please")
    	}
    }
    ```
    
- Nothing의 목적은 컴파일러가 프로그램의 타입 무결성을 검증하도록 도와주는 것이다.

> 아직 어떻게 유용하고, 타입 무결정을 검증하도록 도와주는지 잘 모르겠다
> 

# 6-2. Null 가능 참조

Java에서 null은 항상 오류를 유발할 가능성이 있고, 우리는 null을 절대 피할 수 없다.

만약에 객체를 리턴하는 함수가 호출에서 리턴할 게 아무 것도 없는 경우 Java에서는 null을 리턴해야한다. 이런 방식은 메소드를 호출한 사람이 null 체크를 하지 않고 메소드를 실행시킬 경우 `NullPointerException`을 야기한다.

이런 이슈의 해결책으로 `Optional` 이 등장했지만 `Optional` 사용은 불리한 점을 가지고 있다.

1. 개발자가 `Optional`을 상요해야한다.
    
    즉, 컴파일러가 `Optional`을 사용하도록 강제하지 않기 때문에 안정성이 떨어진다.
    
2. `Optional` 이 객체의 참조 또는 null 참조를 감쌀 때 객체가 없다면 작은 오버헤드가 생긴다.
3. 개발자가 `Optional`이 아니고 `null`을 리턴하더라도 Java 컴파일러는 별다른 경고를 주지 않는다.
    
    그러면 런타임에 NPE가 발생할 여지가 분명히 있다.
    

코틀린에서는 이러한 이슈들이 없다. 컴파일 시간에 개발자에게 null 체크여부를 확인시켜준다.

다음과 같은 순서로 살펴볼 것이다.

1. 일반적으로 null 참조를 사용하는 게 좋지 않은 이유
2. 코틀린 컴파일러가 어떻게 임의의 참조에 null을 할당하지 않을 수 있을까
3. null을 할당할 수 있는 특별한 nullable 타입을 사용하는 방법
4. 코틀린 컴파일러가 제공하는 안전하고 편리한 nullable 참조를 디레퍼런스할 수 있게 하는 연산자

## null**은 에러를 유발한다**

> 이펙티브 자바 - “콜렉션을 리턴하는 함수가 실행 시간에 리턴할 게 아무것도 없다면 null이 아니고 빈 콜렉션을 리턴해야 한다.” 라고 말한다.
> 

`null`을 리턴한다면 결과를 받는 쪽에서 `null`로 인한 오류가 발생할 수 있고, 이를 피하려면 반드시 `null` 체크를 해줘야하는 번거로움이 있기 때문이다.

> 만약 함수의 결과가 콜렉션이 아니고 객체라면 어떨까?
> 

리턴해 줄 참조가 없는 경우 `null`을 리턴하거나, 이를 보완해 `Optional<T>` 를 리턴하도록 권장한다.

(Optional의 단점은 앞서 살펴보았다.)

코틀린에서는 `null`을 `non-nullable` 타입에 할당하거나, `non-nullable` 타입인데 `null`을 리턴하려고 하면 컴파일 오류가 발생하도록 하여 위와 같은 에러(런타임에서 발생하는 NPE)를 피할 수 있게 해준다.

```kotlin
fun nickName(name: String): String {
    if (name == "Solar") {
        return "Holar"
    }
    return null // compile error
}

println("Nickname for Solar is ${nickName("Solar")}")
println("Nickname for Kolar is ${nickName("Kolar")}")
println(nickName(null)) // compile error
```

```kotlin
nonull.kts: (5, 12): Null can not be a value of a non-null type String
nonull.kts: (11, 18): Null can not be a value of a non-null type String
```

위 코드를 Java에서 작성하면 컴파일은 잘 되고, 실행 시간에 오류가 날 것이다. 하지만 코틀린은 `non-nullable`한 `String` 타입에 `null` 을 리턴하는 경우가 있으면 컴파일 시점에 오류를 내뱉는다.

## Null **가능 타입 사용하기**

- `non-nullable` 타입들은 각자 대응되는 `nullable` 타입이 존재한다.
    - 타입이 `null`불가 참조일 경우 검증된 `null` 이 아닌 참조만 넘겨줄 수 있다.
    - `nullable` 타입은 `null` 과 검증된 참조 둘 다 넘겨줄 수 있다.
- **받는 쪽에서 null 체크를 하지 않으면 null 가능 참조를 사용할 수 없다.**
- `nullable` 타입은 타입 이름 뒤에 `?`가 붙는다.

이전 예제의 문제점을 수정해보자.

참조나 null을 리턴하기 위해서 nullalbe한 타입인 `String?` 으로 변경하면서 앞서 오류들이 사라진다.

```kotlin
fun nickName(name: String?): String? {
    if (name == "Solar") {
        return "Holar"
    }
		//return name.reversed() //RUNTIME ERROR
    return null
}

println("Nickname for Solar is ${nickName("Solar")}")
println("Nickname for Kolar is ${nickName("Kolar")}")
println(nickName(null))
```

```kotlin
Nickname for Solar is Holar
Nickname for Kolar is null
null
```

> nullable 타입의 바이트 코드 맵핑nullable 타입은 바이트 코드에서 non-nullable 타입으로 대체된다. 이때, 코틀린 컴파일러가 컴파일 시간에 null 체크를 하기 때문에 실행 시간에는 성능적 오버헤드가 없다.
> 

nickName에서 nullable한 파라미터를 사용하려면 Java에서는 다음과 같이 null 체크코드가 들어갈 것이다.

```kotlin
if (name != null) { //지저분한 null 체크 -> 세이프 콜 연산자를 이용해서 깨끗하게 고쳐보자
	return name.reversed()
}
return null
```

코틀린에서 위 null체크 코드없이 컴파일을 하면 아래와 같이 오류가 난다.

```kotlin
returnnull.kts: (5, 16): Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type String?
```

**코틀린은 `nullable` 참조가 메소드를 호출할 때는 `safe call operator` 또는 `not-null assertion operator` 프리픽스를 사용하도록 요구한다.**  이는 `null`이 메소드를 호출하거나 객체 속성에 접근하는 것을 컴파일 시간에 방지한다.

## **세이프 콜 연산자 - ?**

코틀린에서는 `?` 연산자를 통해 메소드 호출 또는 객체 속성 접근과 `null` 체크를 합칠 수 있다.

- 세이프 콜 연산자는 참조가 `null`일 경우 `null`을 리턴한다.

```kotlin
val name: String? = null
name?.reversed() // no error
name?.reversed()?.toUpperCase() //세이프콜 연산자로 연결할 수 있다.
```

### **엘비스 연산자(Elvis Operator) - ?:**

참조가 `null`일 때, 세이프 콜 연산자의 결과를 `null`이 아닌 다른 값으로 리턴하고 싶다면 엘비스 연산자(`?:`)를 사용하면 된다.

```kotlin
val name: String? = null
val result = name?.reversed() ?: "Joker" //name 참조가 null이면 "Joker"를 리턴
```

## 사용해서는 안될 안전하지 않은 확정 연산자(**`not-null assertion`**) - !!

특정 참조가 절대 `null`이 아니라는 것을 코틀린에게 알려 불필요한 체크를 하지 않도록 만들기 위해선 `not-null assertion`(`!!`)을 사용해야한다.

```kotlin
val name: String? = "Joker"
val result = name!!.reversed() //no-error but BAD CODE
```

> **이 연산자는 사용하지말자!!!!!  `name`이 `null`이라면 런타임 에러가 발생한다. ㅠㅠ**
> 

## 인자 매칭 연산자 - **`when`의 사용**

참조 값이 `null`인 경우와 그렇지 않은 경우에 다르게 동작해야 하는 경우 `when`을 사용할 수 있다.

**as-is**

```kotlin
fun nickName(name: String?): String? {
    if (name == "Solar") {
        return "Holar"
    }
    return name?.reversed()?.toUpperCase() ?: "Joker";
}
```

단순히 값만 추출하지 않고, null 가능 참조의 값에 기반해서 리턴값을 결정하고 있다. 이를 `when`을 사용해서 다음과 같이 수정할 수 있다.

**to-be**

```kotlin
fun nickName(name: String?) = when (name) {
    "William" -> "Bill"
    null -> "Joker"
    else -> **name.reversed().**toUpperCase() //null이 아닌경우만 남기 때문에 ?, ?:이 필요없다.
}
```

이렇게 명확하게 `null`을 구분하면 코틀린 컴파일러가 불필요한 `null` 체크를 하지 않게 된다. 즉, 세이프 콜 연산자나 엘비스 연산자도 필요없게 된다.

> [정리]
세이프 콜, 엘비스 연산자 →값을 추출할 때 사용
when → null 가능 참조에 대한 처리를 결정해야할 떄 사용
> 

# 6-3. 타입 체크와 캐스팅

## 타입 체크

가끔 객체의 타입을 체크하는 것은 필수적이다.

하지만 **확장성의 측면에서 봤을 때 타입체크는 최소한으로만 해야 한다.** 새로운 타입이 추가됐을 때 코드를 부서지기 쉽게 만들고 개방-폐쇄 원칙을 위배한다. 

실행 시간에 타입 체크를 진행할지 여부는 코드를 짜기 전에 여러 번 생각을 해보는 것이 좋다.

코틀린은 `==` 연산자를 equals() 메소드에 맵핑해서 참조가 아닌 동일성을 확인한다. 타입체크를 알아보기 위해서 클래스의 `equals()` 메소드 구현을 예시로 살펴보자

## is 사용하기

- `is` 연산자 : 객체가 참조로 특정 타입을 가리키는지 확인

```kotlin
calss Animal {
    override operator fun equals(other: Any?) = other is Animal
}

val greet: Any = "hello"
val odie: Any = Animal()
val toto: Any = Animal()

//equals() 메소드를 == 연산자로 사용할 수 있다.
println(odie == greet) //false
println(odie == toto) //true
```

- `is` 연산자는 모든 타입의 참조에 사용될 수 있다.
- 참조가 `null`일 경우 → `is` 연산의 결과는 `false`
- 객체의 타입과 비교 타입이 같거나 상속관계 → `is` 연산의 결과는 `true`
- `!is` : 부정
- `is` 나 `!is` 를 사용하면 캐스팅을 공짜로 할 수 있게 된다. (feat. **스마트 캐스트**)

## **스마트 캐스트**

- 코틀린의 참조의 타입이 확인되면 자동 혹은 스마트 캐스팅을 한다.

아래 예시에서 `other`는 `Animal` 타입인게 확인되면 `Animal` 타입으로 자동 캐스팅이 된다.

```kotlin
class Animal(val age: Int) {
    override operator fun equals(other: Any?): Boolean {
    	return if (**other is Animal**) age == **other.age** else false
								 //타입체크가 true이면,      other은 Animal로 자동형변환된다.
    }
}
```

- 스마튼 캐스트는 코틀린이 타입을 확인하는 즉시 작동한다.
- `if`문 뿐만아니라 `||` 혹은 `&&` 연산자 이후에도 동작한다.

```kotlin
class Animal(val age: Int) {
    override operator fun equals(other: Any?)
        = other is Animal && age == other.age
}
```

- **객체가 null 참조가 아니라고 판별하면 null 가능 타입이 null 불가 타입으로 자동으로 캐스팅된다.**

## when과 함께 타입 체크와 스마트 캐스트 사용하기

when 명령문 또는 표현식에 `is` 나 `!is`, 스마트 캐스팅을 사용할 수 있다.

“4-3. When을 사용해야 할 때” 에서 만든 whatToDO() 함수를 보자

```kotlin
fun whatToDo(dayOfWeek: Any) = when (dayOfWeek) {
    "Saturday", "Sunday" -> "Relax"
    is String -> "What, you provided a string of length ${dayOfWeek.length}" //스마트캐스
    else -> "No Clue"
}
```

when에서 사용되는 조건 중 하나는 파라미터가 String인지 확인하기 위해 `is` 연산자로 타입을 체크한다. Any 타입의 파라미터가 해당 조건에 부합할 때는 조건뒤에 나오는 표현식에서는 스마트캐스팅이 완료되어 String으로 취급할 수 있다.

# 6-4. 명시적 타입 캐스팅

- **명시적 타입 캐스팅은 컴파일러가 타입을 확실하게 결정할 수 없어 스마트 캐스팅을 하지 못할 경우에만 사용해야 한다.**
    
    var 변수가 체크와 사용 사이에서 변경되어 코틀린이 타입을 보장해줄 수 없는 경우, 스마트 캐스트를 적용할 수 없기 때문에 개발자가 타입캐스트를 해야만 한다.
    
- 명시적 타입 캐스팅 - `as` , `as?` 연산자
    - `as` : 안전하지 않은 대응 연산자 (사용하지 말자!!!)
        - 캐스팅에 실패하면 에러를 발생시킨다.
        - **객체의 타입이 예상했던 것과 다를 경우 런타임에 예외가 발생한다.** (주의)
    - `as?` : 안전한 대응 연산자
        - null 가능 참조 타입을 결과로 가진다.
        - 캐스팅이 실패하면 `null`을 할당한다.
    
    ```kotlin
    val message: **String** = fetchMessage(1) **as** String
    val message: **String?** = fetchMessage(1) **as?** String
    ```
    

`as` 를 사용해서 런타임 에러가 발생하는 경우와 `as?` 를 사용해 엘비스 연산자와 함께 안전하게 사용한 코드 예제를 살펴보자

```kotlin
fun fetchMessage(id: Int): Any =
    if (id == 1) "Record found" else StringBuilder("data not found")

for (id in 1..2) {
    println("Message length: ${(fetchMessage(id) as String).length}") //unsafety - RUNTIME ERRORERROR
}

for (id in 1..2) {
    println("Message length: ${(fetchMessage(id) as? String)?.length ?: "---"}") //safety
}
```

```kotlin
Message length: 12
java.lang.ClassCastException: java.lang.StringBuilder incompatible with java.lang.String
	at UnsafeCast.<init>(unsafeCast.kts:5)

Message length: 12
Message length: ---
```

### 실무 사용 권장사항

- 가능한 스마트 캐스트를 사용하라
- 스마트 캐스트가 불가능한 경우에만 안전한 캐스트 연산자를 사용하라
- 애플리케이션이 불타거나 무너지는걸 보고 싶다면 안전하지 않은 캐스트 연산자를 사용하라

# 6-5. 제네릭: 파라미터 타입의 가변성과 제약사항

제네릭은 다양한 타입에서 사용 가능한 코드를 만들 수 있으며, 컴파일러는 제네릭 클래스 또는 함수가 의도하지 않은 타입에서 사용되는지 검증할 수 있습니다.

### **타입 불변성**

메소드가 클래스 T의 객체를 받을 때, T 클래스의 자식이라면 어떤 객체든 전달할 수 있다. 하지만 메소드가 타입 T의 제네릭 오브젝트를 받는다면, T의 파생 클래스를 전달할 수는 없다. 이것이 타입 불변성이다. 타입을 변경할 수 없다.

> 예 - List<Animal>을 전달할 수는 있지만 Dog extends Animal이더라도 List<Dog>를 전달할 수는 없다.
> 

아래 예시를 살펴보자. 

> **`Array<Fruit>`**파라미터를 받는 곳에 `Array<Banana>`를 전달한다면?
> 

```kotlin
open class Fruit
class Banana : Fruit()
class Orange : Fruit()

fun receiveFruits(fruits: **Array<Fruit>**) {
    println("Number of fruits: ${fruits.size}")
}

val bananas: Array<Banana> = arrayOf()
receiveFruits(bananas) // ERROR - Type mismatch: inferred type is Array<TypeInvariance.Orange> but Array<TypeInvariance.Fruit> was expected
```

type mismatch ERROR가 발생한다. 이런 제약은 코틀린이 가진 제네릭에 대한 타입 불변성 때문에 발생한다.

`Banana`가 `Fruit`을 상속받는 것이지, `Array<Banana>`가 `Array<Fruit>`을 상속 받는 것은 아니다. **상속**은 **대체 가능성**을 의미한다. 하지만 `Array<Banana>`는 `Array<Fruit>`를 대체할 수 없다. 

예를 들어, 메소드 내부에서 파라미터로 전달받은 `Array<Fruit>`에 `Orange`가 추가되는 로직이 있다면, `Array<Banana>`에는 추가될 수 없기 때문에 Orange를 Banana로 취급을 하게 되면서 캐스팅 예외(타입 미스매치 에러)가 발생한다.

> 그렇다면 `**List<Fruit>**` 파라미터를 받는다면 어떨까?
> 

```kotlin
fun receiveFruits(fruits: **List<Fruit>**) {
    println("Number of fruits: ${fruits.size}")
}

val bananas: List<Banana> = listOf()
receiveFruitsList(bananas) //OK
```

> Type mismatch 에러가 발생하지 않는다. 이렇게 동작이 다른 이유는 무엇일까?
> 

`Array<T>`는 뮤터블하지만 `List<T>`는 이뮤터블하기 때문이다.

개발자가 메소드내에서 `List<Fruit>` 을 변경할 수 없기 때문이다.

> 코틀린이 어떻게 저런 차이점을 알려주는 것일까?
> 

두 타입이 정의되는 방식에 달려있다. `Array<T>`는 `class Array<T>`로 정의되고 `List<T>`는 `interface List<**out** E>` 로 정의된다.

가장 큰 차이는 `out` 에 달려있다.

## **공변성 사용하기**

- 공변성(covariance)이란?
    - 타입 T의 자식 클래스도 사용할 수 있도록 허용하는 것
- Java에서의 공변성
    - Java에서는 `<? extends T>` 문법을 사용해서 공변성을 사용
    - 이 문법에는 제약사항이 있다.
        - 제네릭을 “사용”할 땐 사용이 가능하고, → “사용처 가변성”
        - 제네릭을 “선언”할 떈 사용이 불가능하다. → “선언처 가변성”
- 코틀린은 “사용처 가변성”, “선언처 가변성” 두 경우 모두 사용이 가능하다.

코틀린 컴파일러가 공변성을 허용해서 제네릭 베이스 타입(부모 클래스)이 요구되는 곳에 제네릭 파생 타입(자식 클래스)이 허용되도록 하길 원할 때, **타입 프로젝션(사용처 가변성)**이 필요하다.

다음 두 개의 `Array<Fruit>` 를 전달받는 copyFromTo()메소드를 살펴보자

1번의 경우는 문제가 없지만 2번의 경우 type mismatch 에러가 발생한다.

```kotlin
fun copyFromTo(from: Array<Fruit>, to: Array<Fruit>) {
    for (i in 0 until from.size) {
        to[i] = from[i]
    }
}

//1.
val fruitsBasket1 = Array<Fruit>(3) { _ -> Fruit() }
val fruitsBasket2 = Array<Fruit>(3) { _ -> Fruit() }
copyFromTo(fruitsBasket1, fruitsBasket2) //OK

//2.
val fruitsBasket = Array<Fruit>(3) { _ -> Fruit() }
val bananaBasket = Array<Banana>(3) { _ -> Banana() }
copyFromTo(bananaBasket, fruitsBasket) //ERROR - Type mismatch
```

앞서 살펴본 것 처럼 코틀린은 `Array<Fruit>`파라미터를 받는 곳에 `Array<Banana>`를 전달하지 못하도록 막는다. 타입불변성으로 `Array<T>` 타입은 변경할 수 없다는 것을 알아봤었다.

코틀린에서 `from` 파라미터는 파라미터의 값을 **“읽기만”하기 때문에** `Array<T>`의 `T` 에 `Fruit` 클래스나 `Fruit` 클래스의 하위 클래스가 전달되더라도 아무런 위험이 없다. 이런 것을 타입이나 파생 타입에 접근하기 위한 “**파라미터 타입의 공변성**”이라고 한다.

공변성 파라미터 타입을 사용해서 코드를 수정해보자

- `out` 키워드를 통해 T의 자식 클래스도 파라미터로 전달할 수 있게 타입 프로젝션한다.

```kotlin
fun copyFromTo(from: Array**<out Fruit>**, to: Array<Fruit>) {
    for (i in 0 until from.size) {
        to[i] = from[i]
    }
}

val fruitsBasket = Array<Fruit>(3) { _ -> Fruit() }
val bananaBasket = Array<Banana>(3) { _ -> Banana() }
copyFromTo(bananaBasket, fruitsBasket) //OK
```

단, **이 경우 T의 자식 클래스를 전달받는 파라미터에서 어떤 값도 추가하거나 변경하지 않아야 합니다.**

코틀린은 `from` 레퍼런스에 data가 새로 들어가게 하는 메소드 호출이 없다는 사실을 확인하고 메소드 시그니처가 호출되는 것을 확인하여 이를 검증한다.

예를 들어 아래의 두 호출이 copyFromTo() 안에 있다면 컴파일이 실패하게 된다.

```kotlin
from[i] = Fruit()
from.set(i, to[i])
```

Array<T> 클래스는 T타입의 객체를 읽고, 쓰는 메소드를 모두 가지고 있다. 하지만 **공변성을 하용하기 위해서 우리가 코틀린 컴파일러에게 주어진 Array<T> 파라미터에서 어떤 값도 추가하거나 변경하지 않겠다는 약속을 해야 한다.** 이런 제네릭 클래스를 “사용”하는 관점에서 공변성을 이용하는 것을 “사용처 가변성” 혹은 “타입 프로젝션”이라고 부른다. 

제네릭 타입을 선언할 때 공변성을 사용한다고 지정하는 것은 선언처 가변성이라고 부른다. `List<out T>`로 정의되어 있는 `List` 인터페이스가 좋은 예이다.

(앞서 예시처럼 List가 선언 가변성 정의가 되어있기 때문에 List<Fruit>을 받는 파라미터에 List<Banana>를 전달할 수 있었다.)

## **반공변성**

- 반공변성(contravariance)이란?
    - 타입 T의 부모 클래스를 타입 T가 필요한 자리에서 쓸 수 있도록 허용하는 것
- Java에서의 반공변성
    - Java에서는 `<? super T>` 문법을 사용해서 반공변성을 사용
    - 이 문법에는 제약사항이 있다.
        - 제네릭을 “사용”할 땐 사용이 가능하고, → “사용처 가변성”
        - 제네릭을 “선언”할 떈 사용이 불가능하다. → “선언처 가변성”
- 코틀린은 “사용처 가변성”, “선언처 가변성” 두 경우 모두 사용이 가능하다.

copyFromTo()메소드를 살펴보자. to 파라미터의 타입은 변경 불가능한 Array<Fruit>이다. 

Fruit 콜렉션이나 Fruit 기반의 하위 클래스 콜렉션에 Fruit이나 Frutit의 부모클래스를 전달하고 싶을 때는 어떨까?

**반드시 컴파일러에게 파라미터 타입 인스턴스가 필요한 곳에 파라미터 타입의 베이스 타입(부모 클래스)이 접근할 수 있도록 명시적으로 반공변성 권한을 요청해야 한다.**

반공변성을 사용하지 않고 Array<Any>를 to 자리에 넣으면 어떻게 되는지 확인해보자

```kotlin
fun copyFromTo(from: Array<out Fruit>, to: Array<Fruit>) {
    for (i in 0 until from.size) {
        to[i] = from[i]
    }
}

val things = Array**<Any>**(3) { _ -> Fruit() } //부모타입의 Any
val bananaBasket = Array<Banana>(3) { _ -> Banana() }
copyFromTo(bananaBasket, things) //ERROR - Type mismatch
```

코틀린의 타입 불변성에 의해 에러가 발생한다. 

파라미터 타입에 원래 요청된 타입이나 그 타입의 부모 베이스 타입(반공변성)이 가능하게 하는 권한을 요청해보자.

`in` 키워드를 사용하면 된다.

- `in` 키워드는 메소드가 파라미터에 값을 설정할 수 있게 만들고, 값을 읽을 수 없게 만든다.

```kotlin
// 반공변성 사용하기 - in
fun copyFromTo(from: Array<out Fruit>, to: Array**<in Fruit>**) {
    for (i in 0 until from.size) {
        to[i] = from[i]
    }
}

val things = Array<Any>(3) { _ -> Fruit() } //부모타입의 Any
val bananaBasket = Array<Banana>(3) { _ -> Banana() }
copyFromTo(bananaBasket, things) //OK
```

## where을 사용한 **파라미터 타입 제한**

제네릭은 파라미터에 여러 타입을 쓸 수 있도록 유연함을 제공하지만 때때로 제약조건이 필요한 경우도 있다.

### 단일 제약 조건

아래 예제를 보자. 타입 T는 `close()` 메소드를 실행할 수 있어야 한다. 따라서 타입 제한 제약조건을 통해 `close()` 메소드가 있는 타입만 받을 수 있도록 제약을 걸 수 있다.

```kotlin
// close() 메서드가 있는 AutoCloseable 인터페이스를 구현한 클래스(타입)만 받도록 제한
fun **<T: AutoCloseable>** useAndClos(input: T) {
    input.close()
}
```

`fun` 키워드 뒤에 `<T: AutoCloseable>`을 통해 `AutoCloseable`을 구현한 클래스만 파라미터로 가능하게 제약을 걸 수 있습니다. 이 방법은 하나의 제약조건만 걸 수 있다는 단점이 있습니다. 

### 여러 개의 제약 조건

`where`를 사용해서 여러 개의 제약 조건을 넣을 수 있다.

```kotlin
fun <T> useAndClose(input: T) **where T: AutoCloseable, T: Appendable** {
    input.append("there")
    input.close()
}
```

아래처럼 AutoCloseable 제약 조건을 만족하는 클래스를 전달할 수 있다.

```kotlin
val writer = java.io.StringWriter()
writer.append("hello ")
useAndClose(writer)
println(writer) //hello
```

## **스타 프로젝션<*>**

Java는 개발자가 raw 타입을 직접 만들 수 있따. 예를 들면 `ArrayList`가 있다. 하지만 **raw 타입을 직접 만드는 것은 일반적으로 타입 안정성이 없고 가급적 하지 말아야할 일이다.**

- 파라미터 타입을 정의한다.
- 제네릭 읽기 전용 타입과 raw타입을 위한 코틀린의 기능이다.
- **타입에 대해 정확히는 알 수 없지만 타입 안정성을 유지하면서 파라미터를 전달할 때 사용**된다.
- **읽는 것만 허용하고 쓰는 것은 허용하지 않는다.**

```kotlin
fun printValues(values: Array**<*>**) {
    for (Value in values) {
        println(value)
    }
    //values[0] = values[1] // error - Array<*> 를 파라미터로 받았기 때문에 함수 내에서 어떠한 변경도 허용되지 않는다.
}
printValue(arrayOf(1, 2)) //1\n2
```

printValue() 함수는 `Array<*>` 를 파라미터로 받는다. 그리고 **함수 내에서 어떠한 변경도 허용되지 않는다.**

파라미터를 `Array<T>` 로 작성했다면 ERROR가 발생한 코드를 주석 처리하지 않았어도 컴파일이 됐을 것이다. 이 경우 콜렉션을 반복하는 도중 콜렉션을 변경할 가능성이 있다. 스타 프로젝셔으 이러 부주의한 오류로부터 우리를 보호해준다.

여기서 사용된 스타 프로젝션 `<*>` 은 `out T`와 동일하다.

스타 프로젝션이 선언처 가변성에서 `<in T>`로 정의된 반공분산으로 사용된다면 `in Nothing`을 사용한 것과 같아진다.

이 점을 강조하기 위해서 아무거나 사용하더라도 컴파일 에러가 발생할 것이다. 스타 프로젝션은 모든 작성(쓰기)를 방지하고 안정성까지 제공한다.

# 6-6. 구체화된 타입 파라미터 - reified

Java에서 제네릭을 사용할 때 `Class<T>` 함수를 파라미터로 전달해야 하는 냄새나는 코드를 볼 수 있다. 제네릭 함수에서 특정 타입이 필요하지만 Java의 타입 이레이저 때문에 타입 정보를 잃어버릴 경우 필수적으로 따라온다. 코틀린은 구체화된 타입 파라미터(`Reified Type Parameters`)를 이용해서 악취를 제거했다.

> 구체화를 이해하기 위해 지저분한 코드를 예시로 사용한다.
코드에서 함수에 **클래스 디테일을 파라미터로 전달**하고, **타입 구체화**를 이용해서 리팩토링을 진행해보자
> 

## Java에서 제네릭 특정 타입 사용

Book 클래스와 그 자식 클래스인 Fiction과 NonFiction이 있다.

books는 다른 종류의 책이 있는 리스트이다.

```kotlin
abstract class Book(val name: String)
class Fiction(name: String): Book(name)
class NonFiction(name: String): Book(name)

val books: List<Book> = listOf(
    Fiction("Moby Dick"), NonFiction("Learn to Code"), Fiction("LOTR")
)
```

`List<Book>` 에는 Finction과 NonFiction이 섞여있다. list 안의 Fiction과 NonFiction 중 특정 타입의 첫 번째 인스턴스를 찾아야하다면? 

아마 코틀린 코드를 다음과 같이 Java에서 작성하던 것처럼 작성할 수도 있을 것이다.

```kotlin
// 1. Java에서 작성하던 방식
// 원하는 객체의 타입을 파라미터로 던진다. - ofClass: Class<T>
fun <T> findFirst(books: List<Book>, **ofClass: Class<T>**): T {
    val selected = books.filter { book -> **ofClass.isInstance**(book)} //타입체크
    if (selected.size == 0) {
        throw java.lang.RuntimeException("Not Found")
    }
    return **ofClass.cast**(selected[0]) //타입 캐스팅
}

println(findFirst(books, NonFiction::class.java).name) //Learn to Code
```

**바이트코드로 컴파일되면서 파라미터 타입 T가 지워지기 때문에 함수 안에서 T를 book is T나 selected[0] as T처럼 연산자와 함께 사용할 수 없다. 해결 방법으로 Java와 코틀린 모두에서 우리가 원하는 객체의 타입을 파라미터로 던진다.**

위 예제에서는 `ofClass: Class<T>` 의 방법을 사용했다. 그리고 코드에서 `ofClass` 를 타입 체크와 타입 캐스팅을 위해서 사용했다. (장황하다… 지저분하다…. 고쳐보자…)

함수가 호출될 때마다 프로그래머는 런타임 타입 정보를 추가적인 아규먼트로 전달해야만 한다. 그러면 호출하는 쪽과 받는 쪽 모두에게 나쁜 코드를 만들게 된다. 이런 행위는 코드에 오류가 나도록 하는 경향이 있따.

코틀린에서는 이러한 문제를 `**reified`(구체화) 타입 파라미터**를 통해 해결한다.

## 코틀린에서 구체화된(reified) 타입 파라미터를 사용하기

코틀린도 타입 이레이저의 한계를 다뤄야 한다. 실행 시간에 파라미터 타입은 사용할 수 없다. 하지만 코틀린은 **파라미터 타입이 `reified`라고 마크되어 있고 함수가 `inline`으로 선언되었다면 우리가 파라미터 타입을 사용할 수 있도록 권한을 준다.**

( * 인라인 함수 : 컴파일 시점에서 확정되므로 함수 호출 시 오버헤드는 없는 함수 [10-6.람다를 이용한 인라인 함수 참고] )

findFirst()함수를 `reified`로 리팩토링해보자

```kotlin
// 2. 코틀린에서 구체화된(reified) 타입 파라미터를 사용하기
**inline** fun **<reified  T>** findFirst(books: List<Book>): T {
    val selected = books.filter { book -> book **is T** } //T를 타입 체크로 사용
    if (selected.size == 0) {
        throw RuntimeException("Not Found")
    }

    return selected[0] **as T** //T를 타입 캐스팅용으로 사용
}

println(findFirst**<Fiction>**(books).name) //Moby Dick
```

- 파라미터 타입 `T`를 `reified`로 선언
- `Class<T>` 파라미터를 제거
- **함수 안에서 T를 타입 체크와 캐스팅용으로 사용 가능하다.** (WoW!!!)
- 함수가 inline으로 선언되어 있기 때문에(reified는 inline 함수에서만 사용 가능하다.) 함수의 바디가 함수 호출하는 부분에서 확장된다.
- 함수의 가독성도 증가하고, 함수를 호출하는 코드도 간편해진다.

### [정리] 구체화된 타입 파라미터(Reified type Parameter)의 장점

- 클러터를 지우는데 유용
- 잠재적인 코드의 오류를 제거하는데 도움이 된다.
- 함수에 추가적인 클래스 정보를 전달하지 않도록 만들어주고, 코드에서 캐스팅을 안전하게 해준다.
- 컴파일 시간 안정성을 확보한 채로 리턴타입을 커스터마이징할 수 있게 해준다.

reified 타입 파라미터를 사용하는 대표적인 함수

- 코틀린 스탠다드 라이브러리 - listOf<T>(), mutableListOf<T>()
- klaxon 라이브러리 - parse<T> (비동기 프로그래밍에서 다룬다.)