### PR TITLE
[다재다능 코틀린 프로그래밍] ch07 - 객체와 클래스

### DIFF
--- a/kotlin-programming/.idea/kotlinScripting.xml
+++ b/kotlin-programming/.idea/kotlinScripting.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KotlinScriptingSettings">
+    <scriptDefinition className="org.jetbrains.kotlin.idea.core.script.StandardIdeScriptDefinition" definitionName="Kotlin Script">
+      <order>2147483647</order>
+      <autoReloadConfigurations>true</autoReloadConfigurations>
+    </scriptDefinition>
+  </component>
+</project>

--- a/kotlin-programming/src/main/kotlin/ch07/Car.kt
+++ b/kotlin-programming/src/main/kotlin/ch07/Car.kt
@@ -1,0 +1,9 @@
+package ch07
+
+//yearOfMake, color 모두 필드가 아니고 속성이다. 코틀린에서는 클래스에 필드가 없다.
+//`car.yearOfMake` 를 호출하면 실제로는 `car.getYearOfMake()`를 호출한 것이다.
+class Car(val yearOfMake: Int, var color: String)
+
+//javap 툴을 이용해서 코드를 컴파일하고 바이트코드를 살펴보자
+//kotlinc-jvm Car.kt //Car.class 파일을 만들어준다. (package가 있다면 package 하위 경로에)
+//javap -p Car.calss //class 파일 디셈블러

--- a/kotlin-programming/src/main/kotlin/ch07/SSN.kt
+++ b/kotlin-programming/src/main/kotlin/ch07/SSN.kt
@@ -1,0 +1,11 @@
+package ch07
+
+//inline 클래스
+inline class SSN(val id: String)
+fun receiveSSN(ssn: SSN) {
+    println("Received $ssn")
+}
+
+fun main() {
+    receiveSSN(SSN("111-11-1111"))
+}

--- a/kotlin-programming/src/main/kotlin/ch07/UseCar.kt
+++ b/kotlin-programming/src/main/kotlin/ch07/UseCar.kt
@@ -1,0 +1,10 @@
+package ch07
+
+//yearOfMake, color는 필드가 아니고 속성이다. 코틀린에서는 클래스에 필드가 없다.
+fun useCarObject(): Pair<Int, String> {
+    val car = Car(2019, "Red")
+    val year = car.yearOfMake
+    car.color = "Green"
+    val color = car.color
+    return year to color
+}

--- a/kotlin-programming/src/main/kotlin/ch07/anonymous.kts
+++ b/kotlin-programming/src/main/kotlin/ch07/anonymous.kts
@@ -1,0 +1,27 @@
+//인터페이스를 구현한 익명 객체
+fun createRunnable(): Runnable {
+    val runnable = object : Runnable { //Runnable 인터페이스를 구현
+        override fun run() {
+            println("You called......")
+        }
+    }
+    return runnable
+}
+val aRunnable = createRunnable()
+aRunnable.run() //You called......
+
+//싱글 추상 메소드 인터페이스(Java8의 함수형 인터페이스)라면 메소드 이름을 명명하지 않고 바로 구현할 수 있다.
+fun createRunnable2(): Runnable = Runnable { println("You called......?") }
+val bRunnable = createRunnable2()
+bRunnable.run() //You called......?
+
+//둘 이상의 인터페이스를 구현한다면 리턴이 필요한 경우 반드시 리턴할 인스턴스 타입을 명시해줘야 한다.
+fun createRunnable3(): Runnable = object: Runnable, AutoCloseable { //Runnable과 AutoCloseable를 구현. 리턴타입은 Runnable
+    override fun run() {
+        println("You called.......!")
+    }
+
+    override fun close() {
+        println("closing...")
+    }
+}

--- a/kotlin-programming/src/main/kotlin/ch07/companion.kts
+++ b/kotlin-programming/src/main/kotlin/ch07/companion.kts
@@ -1,0 +1,25 @@
+//컴패니언 객체와 클래스 멤버
+class MachineOperator(val name: String) {
+    fun checkin() = checkedIn++
+    fun checkout() = checkedIn--
+
+    //컴페니언 객체
+//    companion object { //1. 컴패니언 객체에 이름이 없는 경우
+    companion object MachineOperatorFacotry{ //2. 컴패니언 객체에 이름을 지정
+        var checkedIn = 0 //클래스 레벨 속성
+        fun minimumBreak() = "15 minutes every 2 hours" //클래스 레벨 메소드
+    }
+}
+
+val solarMachine = MachineOperator("Solar").checkin()
+println(MachineOperator.minimumBreak()) //15 minutes every 2 hours
+println(MachineOperator.checkedIn) //1
+//println(solarMachine.minimumBreak()) //ERROR. 컴패니언 메소드는 인스턴스를 이용해서 접근할 수 없다.
+
+//컴패니언에 접근하는 방법
+//val ref = MachineOperator.Companion //1. Companion은 컴패니언 객체에 명확한 이름이 없을 경우에만 사용
+val ref = MachineOperator.MachineOperatorFacotry //2. 컴패니언 객체에 지정된 이름을 사용. Companion은 사용 불가
+println(ref.checkedIn)
+
+
+

--- a/kotlin-programming/src/main/kotlin/ch07/factory.kts
+++ b/kotlin-programming/src/main/kotlin/ch07/factory.kts
@@ -1,0 +1,22 @@
+//MachineOperator 클래스가 팩토리를 사용하도록 변경
+class MachineOperator private constructor(val name: String) { //1.클래스에 privatre 생성자를 만든다.
+    fun checkin() = checkedIn++
+    fun checkout() = checkedIn--
+
+    //컴페니언 객체
+    companion object {
+        var checkedIn = 0 //클래스 레벨 속성
+        fun minimumBreak() = "15 minutes every 2 hours" //클래스 레벨 메소드
+
+        //팩토리
+        fun create(name: String): MachineOperator {
+            val instance = MachineOperator(name)
+            instance.checkin() //인스턴스를 리턴하기 전에 사전 작업
+            return instance
+        }
+    }
+}
+
+val operator = MachineOperator.create("Solar")
+println(MachineOperator.checkedIn) //1
+println(operator.name) //Solar

--- a/kotlin-programming/src/main/kotlin/ch07/initialization.kts
+++ b/kotlin-programming/src/main/kotlin/ch07/initialization.kts
@@ -1,0 +1,13 @@
+import java.lang.RuntimeException
+
+class Car(val yearOfMake: Int, theColor: String) {
+    var fuelLevel = if (yearOfMake < 2020) 90 else 100
+        private set //setter 접근 제어자 변경
+    var color = theColor
+        set(value) {
+            if (value.isBlank()) {
+                throw RuntimeException("no empty, please")
+            }
+            field = value
+        }
+}

--- a/kotlin-programming/src/main/kotlin/ch07/object.kts
+++ b/kotlin-programming/src/main/kotlin/ch07/object.kts
@@ -1,0 +1,10 @@
+// 객체 표현식으로 사용하는 익명 객체
+fun drawCircle() {
+    val circle = object { //an expression
+        val x = 10
+        val y = 20
+        val radius = 30
+    }
+    println("Circle x: ${circle.x} y: ${circle.y} radius: ${circle.radius}") //Circle x: 10 y: 20 radius: 30
+}
+drawCircle()

--- a/kotlin-programming/src/main/kotlin/ch07/prioritypair.kts
+++ b/kotlin-programming/src/main/kotlin/ch07/prioritypair.kts
@@ -1,0 +1,20 @@
+//제네릭 클래스 생성
+// 파라미터 타입과 제약 조건 T: Comparable<T>
+class PriorityPair<T: Comparable<T>>(member1: T, member2: T) {
+    val first: T
+    val second: T
+    init {
+        if (member1 >= member2) {
+            first = member1
+            second = member2
+        } else {
+            first = member2
+            second = member1
+        }
+    }
+
+    override fun toString() = "$first, $second"
+}
+
+println(PriorityPair(2, 1))         //2, 1
+println(PriorityPair("A", "B"))     //B, A

--- a/kotlin-programming/src/main/kotlin/ch07/property.kts
+++ b/kotlin-programming/src/main/kotlin/ch07/property.kts
@@ -1,0 +1,6 @@
+// 클래스에 속성 정의
+class Car(val yearOfMake: Int) //주생성자, yearOfMake : 읽기 전용 속성
+
+val car = Car(2019) //인스턴스 생성
+println(car.yearOfMake) //2019
+//car.yearOfMake = 2020 //ERROR. Val cannot be reassigned

--- a/kotlin-programming/src/main/kotlin/ch07/readwrite.kts
+++ b/kotlin-programming/src/main/kotlin/ch07/readwrite.kts
@@ -1,0 +1,5 @@
+// 뮤터블 속성
+class Car(val yearOfMake: Int, var color: String)
+val car = Car(2019, "Red")
+car.color = "Green" //뮤터블 속성은 변경가능하다.
+println(car.color) //Green

--- a/kotlin-programming/src/main/kotlin/ch07/secondary.kts
+++ b/kotlin-programming/src/main/kotlin/ch07/secondary.kts
@@ -1,0 +1,24 @@
+// 보조 생성자
+class Person(val first: String, val last: String) { //주 생성자 - 주 생성자에서의 constructor 키워드는 선택사항
+    var fulltime = true //클래스 내부에서 선언된 속성
+    var location: String = "-"
+    // 보조 생성자 1
+    constructor(first: String, last: String, fte: Boolean): this(first, last) { //this() -> 주 생성자 호출
+        fulltime = fte
+    }
+    // 보조 생성자 2
+    constructor(first: String, last: String, loc: String) : this(first, last, false) {//this() -> 보조 생성자 1 호출
+        location = loc
+    }
+    override fun toString() = "$first $last $fulltime $location"
+    internal fun fullName() = "$last, $first"
+    private fun yearsOfService(): Int = throw RuntimeException("Not implemented yet")
+}
+
+println(Person("Solar", "Kim")) //Solar Kim true -
+println(Person("Solar", "Kim", false)) //Solar Kim false -
+println(Person("Solar", "Kim", "home")) //Solar Kim false home
+
+val solar = Person("Solar", "Kim")
+println(solar.fullName())
+//println(solar.yearsOfService()) //ERROR. Cannot access 'yearsOfService'

--- a/kotlin-programming/src/main/kotlin/ch07/setter.kts
+++ b/kotlin-programming/src/main/kotlin/ch07/setter.kts
@@ -1,0 +1,28 @@
+import java.lang.RuntimeException
+
+class Car(val yearOfMake: Int, theColor: String) { // 속성1 : yearOfMake, 파라미터 : theColor(필드가 아님)
+    var fuelLevel = 100 //속성2
+    var color = theColor //속성2
+    set(value) { //color의 setter를 재정의
+        if (value.isBlank()) { //color의 validation을 체크
+            throw RuntimeException("no empty, please")
+        }
+        field = value //field 키워드를 사용한 백킹 필드를 사용하지 않는다면 백킹 필드가 생성되지 않는다. setter나 getter 중 하나만 작성한다면 백킹 필드가 생성된다.
+    }
+    init {
+        if (yearOfMake < 2020) {
+            fuelLevel = 90 //fuelLevel 속성에 접근해야만 하기 때문에 fuelLevel을 정의하는 시점보다 init 블록이 앞에 있으면 안 된다.
+        }
+    }
+}
+
+val car = Car(2019, "Red")
+car.color = "Green"
+car.fuelLevel--
+println(car.fuelLevel) //99
+try {
+    car.color = ""
+} catch(ex: Exception) {
+    println(ex.message) //no empty, please //message 속성을 이용 - getMessage()가 아닌
+}
+println(car.color) //Green

--- a/kotlin-programming/src/main/kotlin/ch07/singleton.kts
+++ b/kotlin-programming/src/main/kotlin/ch07/singleton.kts
@@ -1,0 +1,13 @@
+// 싱글톤이 부모 클래스나 인터페이스를 가지고 있다면 싱글톤은 참조로 할당되거나 부모 타입의 파라미터로 전달될 수 있다.
+object Sun : Runnable {
+    val radiusInKM = 696000
+    var coreTemperatureInC = 1500000 //싱글톤에 뮤터블한 상태를 두는 것은 좋지않다. 특히 멀티스레드 앱이라면 더 더욱
+    override fun run() {
+        println("spin...")
+    }
+}
+fun moveIt(runnable: Runnable) { //싱글톤의 부모 타입의 파라미터로 전달 가능
+    runnable.run()
+}
+println(Sun.radiusInKM) //696000 //싱글톤 속성에 접근
+moveIt(Sun) //spin...

--- a/kotlin-programming/src/main/kotlin/ch07/taskdataclass.kts
+++ b/kotlin-programming/src/main/kotlin/ch07/taskdataclass.kts
@@ -1,0 +1,22 @@
+//데이터 클래스
+data class Task(val id: Int, val name: String, val completed: Boolean, val assigned: Boolean)
+
+val task1 = Task(1, "Create Project", false, true)
+println(task1) //Task(id=1, name=Create Project, completed=false, assigned=true)
+println("Name: ${task1.name}") //Name: Create Project
+
+//copy() : 대상 객체의 모든 속성을 복사해서 새 객체를 생성하는 메소드
+val task1Completed = task1.copy(completed = true, assigned = false) //복사하면서 속성 2개를 변경
+println(task1Completed) //Task(id=1, name=Create Project, completed=true, assigned=false)
+
+//componentN() : 주 생성자에 의해서 정의된 각각의 속성에 접근할 수 있게 해주는 메소드
+// 구조 분해
+val id = task1.id
+val isAssigned = task1.assigned
+println("Id: $id Assigned: $isAssigned") //Id: 1 Assigned: true
+
+//데이터 클래스의 구조분해 기능
+//- 주 생성자가 만든 속성 순서와 동일한 속성 순서로 속성을 추출
+//- 언더스코어(`_`) : skip할 속성
+val (id2, _, _, isAssigned2) = task1
+println("Id2: $id2 Assigned2: $isAssigned2") //Id2: 1 Assigned2: true

--- a/kotlin-programming/src/main/kotlin/ch07/util.kts
+++ b/kotlin-programming/src/main/kotlin/ch07/util.kts
@@ -1,0 +1,6 @@
+//객체 선언을 이용한 싱글톤
+// object 키워드와 {} 블록 사이에 이름을 넣는다면, 코틀린은 이를 표현식이 아니라 명령문 또는 선언(Declaration)으로 인식한다.
+object Util {
+    fun numberOfProcessors() = Runtime.getRuntime().availableProcessors()
+}
+println(Util.numberOfProcessors()) //12


### PR DESCRIPTION
# CH07.  객체와 클래스

- 코틀린의 클래스 - Java에서 클래스를 만드는 것과 의미상으로 비슷하지만 많은 차이점이 있다.
- 싱클톤, 클래스, 동반 객체(companion object)

코틀린은 클래스 생성자를 함수처럼 사용할 수 있다.(new 키워드가 없다.)

필드를 구현해준다. (필드를 따로 정의할 필요가 없다.)

개발자는 속성만 정의하면 코틀린이 필요한 부분에 백킹 필드를 만들어준다.

> **백킹 필드**
> 
> - 클래스의 속성 정보
> - 자바 빈 스펙 참고 - 프로퍼티와 필드는 다르다.
> - 자바는 필드가 없거나 필드 이름이 ‘aaa’여도 `getName()`, `setName()` 이라는 게터, 세터가 있으면,  `getName()`, `setName()` 가 **프로퍼티**가 된다.
>     
>     이 때 사용되는 필드인 ‘aaa’가 백킹 필드라고 한다.
>     
> - 즉, 프로퍼티는 메서드(명)를 가지고 정의가 된다.

# 7-1. 객체와 싱글톤

싱글톤을 구현의 어려움

- 생성자에 리플렉션의 접근을 방지, 스레드 안정성 보장, 인스턴스가 존재하는지를 확인하는 과정에서 오버헤드를 발생시켜서는 안 된다.
- **코틀린은 싱글톤을 직접 지원한다.**

## 객체 표현식으로 사용하는 익명 객체

객체가 필요하면 객체를 가져야 한다. 코틀린의 객체 표현식은 Java의 **익명 클래스**(Anonymous Class)를 생성하는 데 유용하게 쓰인다.

- 선언 방식 - **`object {}`**

```kotlin
//표현식 : 값으로 대체되는 식
//객체 표현식으로 사용하는 익명 객체
fun drawCircle() {
    val circle = **object {** //an expression
        val x = 10
        val y = 20
        val radius = 30
    }
    println("Circle x: ${circle.x} y: ${circle.y} radius: ${circle.radius}") //Circle x: 10 y: 20 radius: 30
}
drawCircle()
```

- 객체 표현식 : 여러 개의 지역변수를 그룹핑해 준다.
- 객체에 메소드를 추가하는 것도 가능. 하지만 그렇게까지 해야 한다면 익명 객체를 사용하기보다는 그냥 클래스를 정의하는 편이 좋은 선택일 것이다.
- 익명 객체가 가지는 한계
    - 익명 객체의 내부 타입은 함수나 메소드의 리턴타입, 파라미터가 될 수 없다.
    - 클래스 안에 저장된 속성들이 있따면, 해당 속성들은 Any로 간두된다. 그러면 모든 속성이나 메소드에 직접 접근할 수 없게 된다.
- 정리하자면 대부분의 기초적인 **객체 표현식은 지역변수들을 그룹핑할 때만 유용하게 쓰인다.**

### 인터페이스의 구현

- Java의 익명 내부 객체와 동일
    - 익명 내부 객체는 전통적으로 즉석에서 인터페이스를 구현하는 데 사용된다.
- 선언 방식 - `**object: 인터페이스명, 인터페이스명 {}**`
    - object 키워드와 블록 사이에 구현하길 원하는 인터페이스의 이름을 쉼표로 구분하여 작성
    - object 키워드 뒤에 콜론(`:`)을 적어야 한다.

Runnable 인터페이스를 구현해보자.

```kotlin
//인터페이스를 구현한 익명 객체
fun createRunnable(): Runnable {
    val runnable = **object : Runnable {** //Runnable 인터페이스를 구현
        override fun run() {
            println("You called......")
        }
    }
    return runnable
}
val aRunnable = createRunnable()
aRunnable.run() //You called......
```

싱글 추상 메소드 인터페이스(Java8 함수형 인터페이스)라면 메소드 이름을 명명하지 않고 바로 구현할 수 있다.

```kotlin
fun createRunnable(): Runnable = Runnable { println("You called......?") }
```

익명 내부 클래스가 둘 이상의 인터페이스를 구현한다면 리턴이 필요한 경우 반드시 리턴할 인스턴스 타입을 명시해줘야 한다.

```kotlin
//둘 이상의 인터페이스를 구현한다면 리턴이 필요한 경우 반드시 리턴할 인스턴스 타입을 명시해줘야 한다.
fun createRunnable3(): Runnable = object: Runnable, AutoCloseable { //Runnable과 AutoCloseable를 구현. 리턴타입은 Runnable
    override fun run() {
        println("You called.......!")
    }

    override fun close() {
        println("closing...")
    }
}
```

함수 외부에서 익명 내부 클래스가 구현한 인터페이스를 이용해서 익명 내부클래스의 인스턴스에 접근이 가능하다.

Java에서 익명 내부 클래스를 사용한 부분이라면 어디든지 코틀린의 객체 표현식을 사용할 수 있다.

## 객체 선언을 이용한 싱글톤

- object 키워드와 {} 블록 사이에 이름을 넣는다면, 코틀린은 이를 표현식이 아니라 **명령문** 또는 **선언**(Declaration)으로 인식한다.
- 선언 방식 - `**object 이름 {}**`
- 익명 이너클래스의 인스턴스 생성 시 → **객체 표현식** 사용
- 싱글톤을 만들 때 → **객체 선언**을 사용

```kotlin
// Kotlin
**object Util {**
    fun numberOfProcessors() = Runtime.getRuntime().availableProcessors()
}
println(Util.numberOfProcessors()) //12

// Java
public static final class Util {
    public static final int numberOfProcessors() {
        return Runtime.getRuntime().availableProcessors()
    }
}
```

객체 선언을 이용해서 만들 Util 객체가 싱글톤이다. 위 코드에서 Util로는 객체 생성 불가하다. 코틀린 컴파일러는 Util을 클래스로 취급하지 않는다. **Util은 이미 객체상태**이다. Java의 private 생성자와 static 메소드만 가지고 있는 클래스와 동일하고 @JvmStatic 어노테이션을 사용하지 않았다면 해당 메소드는 바이트코드에서 static이 되지 않는다. (”static 메소드 생성”에서 살펴본다.)

싱글톤은 메소드만 가질 수 있는게 아니다. val과 var로 선언된 속성 모두를 가질 수 있다. 객체 선언은 객체 표현식처럼 인터페이스를 구현가능하고 이미 존재하는 클래스를 확장할 수 있다.

싱글톤이 부모 클래스나 인터페이스를 가지고 있다면 싱글톤은 참조로 할당되거나 부모 타입의 파라미터로 전달될 수 있다.

```kotlin
// 싱글톤이 부모 클래스나 인터페이스를 가지고 있다면 싱글톤은 참조로 할당되거나 부모 타입의 파라미터로 전달될 수 있다.
object Sun : Runnable {
    val radiusInKM = 696000
    var coreTemperatureInC = 1500000 //싱글톤에 뮤터블한 상태를 두는 것은 좋지않다. 특히 멀티스레드 앱이라면 더 더욱
    override fun run() {
        println("spin...")
    }
}
fun moveIt(runnable: Runnable) { //싱글톤의 부모 타입의 파라미터로 전달 가능
    runnable.run()
}
println(Sun.radiusInKM) //696000 //싱글톤 속성에 접근
moveIt(Sun) //spin...
```

## 탑레벨 함수 vs 싱글톤

> 객체지향 콘셉트에 깊게 들어가기 전에 먼저 탑레벨 함수 대신 싱글톤을 선택해야 할 상황들을 논의해보자
> 

- 패키지 안에 직접 넣어서 **탑레벨 함수**로 사용하는 게 좋은 경우
    - 사용할 함수들이 하이레벨이거나 일반적이거나 넓게 사용될 예정
- **싱글톤**을 사용하는게 좋은 경우
    - 함수들이 서로 연관되어 있을 때
    - 함수들이 상태에 관되어 있을 때
- 싱글톤에 **뮤터블한 상태**를 사용하면 멀티스레드 애플리케이션에서 문제를 유발할 수 있어서 사용에 주의해야 한다.

우리가 프로그램의 **행동(프로세스), 계산, 작동**에 집중할 때 **함수와 싱글톤**이 적절하다. 하지만, **상태**를 다뤄야 한다면 **클래스**를 사용하는게 더 좋은 선택이다.

# 7-2. 클래스 생성

## 가장 작은 클래스

- 선언 : 클래스명 앞에 `class` 키워드

```kotlin
Class Car
```

속성, 상태, 동작 아무런 것도 없다.

## 읽기전용 속성

```kotlin
class Car(val yearOfMake: Int) //주생성자, yearOfMake : 읽기 전용 속성
```

속성을 정의하면 코틀린 컴파일러는 다음 작업을 한다.

- 주생성자 작성
- 필드에 접근하게 해주는 getter 추가

위의 한줄은 아래 내용을 축약해서 적은 것이다.

```kotlin
public class Car public contructor(public val yearOfMake: Int)
```

- 클래스의 멤버가 public이면 생성자 역시 public이다.
- `constructor` 키워드는 접근제어자나 주 생성자용 표기를 사용할 게 아니라면 필요없다.

## 인스턴스 생성하기

- new 키워드가 필요없다. 함수를 사용하듯 그냥 클래스 이름을 이용한다.

```kotlin
val car = Car(2019) //인스턴스 생성
println(car.yearOfMake) //2019
//car.yearOfMake = 2020 //ERROR. Val cannot be reassigned
```

속성 선언 시 val로 선언했기 떄문에 이뮤터블이 된다. 재할당하려고 하면 에러가 난다.

## 읽기-쓰기 속성

- 뮤터블 속성을 만들 수 있다.

```kotlin
class Car(val yearOfMake: Int, var color: String)
val car = Car(2019, "Red")
car.color = "Green" //뮤터블 속성은 변경가능하다.
println(car.color) //Green
```

## 들여다보기 - 필드와 속성

이전 예제의 `yearOfMake`, `color` 은 (Java의 관점에서 봤을 떄 속성이라기보다는 필드에 가깝다. 하지만)

- **모두 필드가 아니고 속성이다. 코틀린에서는 클래스에 필드가 없다.**
- 코틀린에선 getter, setter 대신 속성의 이름을 이용해서 속성에 접근할 수 있다.
- `car.yearOfMake` 를 호출하면 실제로는 `car.getYearOfMake()`를 호출한 것이다.
(자바에서 처럼 직접 필드에 접근할 수 없다.)

컴파일러는 JavaBean 컨벤션을 존중한다. 코틀린 컴파일러로 바이트코드를 생성하는 실험을 해보자

1. Car 클래스를 분리하여 Car.kt 파일을 작성하자
    
    ```kotlin
    //Car.kt
    class Car(val yearOfMake: Int, var color: String)
    ```
    
2. javap 툴을 이용해서 코드를 컴파일하고 바이트코드를 살펴보자
    
    ```kotlin
    kotlinc-jvm Car.kt //Car.class 파일을 만들어준다. (package가 있다면 package 하위 경로에)
    javap -p Car.calss //class 파일 디셈블러
    ```
    
    > `javap` 커맨드 : 
    자바 클래스 파일 역어셈블러
    어떤 바이트코드 파일이 어디서부터 나왔으며, 어떠한 필드와 메소드를 갖고 있는 파일인지를 알려주는 기능
    > 
    
    ![Untitled](https://s3-us-west-2.amazonaws.com/secure.notion-static.com/9a3a251b-07e5-4f9e-8c11-8ddc8be82d96/Untitled.png)
    
3. 코틀린 컴파일러가 생성한 Car 클래스의 바이트코드이다.
    
    ```kotlin
     javap -p Car.class
    Compiled from "Car.kt"
    public final class ch07.Car {
      **private final int yearOfMake; //백킹필드
      private java.lang.String color; //백킹필드 - private으로 자바에서 필드에 직접 접근할 수 없다.**
      public ch07.Car(int, java.lang.String); //생성자
      public final int getYearOfMake(); //getter
      public final java.lang.String getColor(); //getter
      public final void setColor(java.lang.String); //setter
    }
    ```
    
    Car 클래스 한줄의 코드를 코틀린 코드가 속성을 위한 두 개의 백킹 필드(backing field), 생성자, 두 개의 getter, 하나의 setter로 바뀌었다.
    
    > **“프로퍼티(속성)와 필드는 다르다.”** (자바 빈 스펙 참고) **백킹 필드란?**
    자바는 필드가 없거나 필드 이름이 ‘aaa’여도 getName(), setName()이라는 게터, 세터가 있으면 프로퍼티는 메서드(명)을 가지고 정의가 된다.
    이 때 사용되는 ‘aaa’필드를 백킹 필드(뒷받침하는 필드)라고 한다.
    > 

**객체를 사용할 때 필드에 직접 접근을 할 수 없는지 검증해보자.**

```kotlin
fun useCarObject(): Pair<Int, String> {
    val car = Car(2019, "Red")
    val year = car.yearOfMake //**getYearOfMake()가 사용됨**
    car.color = "Green" //setter가 사용됨
    val color = car.color //getter가 사용됨
    return year to color //이 때 객체의 필드에 직접 접근하는 동작이 수행되기 떄문에 문제가 발생하는 건가?
}
```

```kotlin
$ kotlinc-jvm Car.kt UseCar.kt
$ javap -c UseCarKt.class
Compiled from "UseCar.kt"
public final class ch07.UseCarKt {
  public static final kotlin.Pair<java.lang.Integer, java.lang.String> useCarObject();
    Code:
       0: new           #10                 // class ch07/Car
       3: dup
       4: sipush        2019
       7: ldc           #12                 // String Red
       9: invokespecial #16                 // Method ch07/Car."<init>":(ILjava/lang/String;)V
      12: astore_0
      13: aload_0
      14: invokevirtual #20                 // Method ch07/Car.**getYearOfMake**:()I
      17: istore_1
      18: aload_0
      19: ldc           #22                 // String Green
      21: invokevirtual #26                 // Method ch07/Car.**setColor**:(Ljava/lang/String;)V
      24: aload_0
      25: invokevirtual #30                 // Method ch07/Car.**getColor**:()Ljava/lang/String;
      28: astore_2
      29: iload_1
      30: invokestatic  #36                 // Method java/lang/Integer.valueOf:(I)Ljava/lang/Integer;
      33: aload_2
      34: invokestatic  #42                 // Method kotlin/TuplesKt.to:(Ljava/lang/Object;Ljava/lang/Object;)Lkotlin/Pair;
      37: areturn
}
```

출력 내용을 보면 ‘필드에 직접 접근할 수 없다’고 나온다. “어디..?”

코드는 JavaBean 컨벤션을 잘 따르고 있고 캡슐화를 깨뜨리지 않는다. 

## 속성 제어 변경

빈 문자열로 color 속성값을 설정할 수 없도록 클래스를 수정하자.

클래스에 다른 속성을 추가하지만, 추가된 속성은 생성자에 의해 값이 설정되지 않는다.

```kotlin
//setter.kts
class Car(val yearOfMake: Int, theColor: String) { // 속성1 : yearOfMake, 파라미터 : theColor(필드가 아님)
    var fuelLevel = 100 //속성2
    var color = theColor //속성2
    **set(value)** { //color의 setter를 재정의
        if (value.isBlank()) { //color의 validation을 체크
            throw RuntimeException("no empty, please")
        }
        **field** = value //field 키워드를 사용한 백킹 필드를 사용하지 않는다면 백킹 필드가 생성되지 않는다. setter나 getter 중 하나만 작성한다면 백킹 필드가 생성된다.
    }
}
```

- 코틀린에서 개발자는 필드를 만들 수 없다.
(백킹 필드는 필요한 경우에만 자동으로 생성된다.)
- 커스텀 getter와 setter를 가진 필드를 정의하고 `field` 키워드를 사용한 백킹 필드를 사용하지 않는다면 백킹 필드가 생성되지 않는다. setter나 getter 중 하나만 작성한다면 백킹 필드가 생성된다.
1. 생성자(`(val yearOfMake: Int, theColor: String)`)에서 하나의 속성 `yearOfMake`를 정의,
    
    `theColor`라는 파라미터(필드가 아니다.)를 사용했다. 이 파라미터에는 val이나 var를 사용하지 않았다.
    
    > val, var을 사용하지 않아서 속성이 아니라 파라미터인가? 맞는듯!
    > 
2. `fuelLevel` 속성을 생성하고 값을 초기화
    - 코틀린은 `fuelLevel`에 사용되는 getter와 setter를 만들어 낸다.
3. 속성 `color` 를 생성하면서 생성자에서 받아온 파라미터인 `theColor`의 값을 할당
    
    > 같은 이름의 속성과 파라미터를 사용하면 코드를 읽을 때 혼란스럽기 때문에, 속성과 파라미터는 다른 이름을 사용하도록 하자
    > 
    - 코틀린은 `color` 속성의 getter만 만들고 setter는 제공되는 코드를 사용한다.
    - set의 파라미터의 타입도 지정할 수 있다. (예제에선 컴파일러 속성 초기화의 타입에 기반해서 이미 타입을 알고 있다.)
    - **전달받은 값이 사용 가능하다면 값을 스페셜 키워드인 `field` 에 의해서 참조되고 있는 필드에 할당한다. 코틀린이 필드를 내부적으로 만들었기 떄문에 코드에서 필드에 접근할 수 있는 방법이 없다.**
        
        **개발자는 getter나 sette에 있는 `field` 키워드를 통해서만 필드를 사용할 수 있다.**
        

변경된 클래스를 사용해서 필드에 접근해보자

```kotlin
val car = Car(2019, "Red")
car.color = "Green"
car.fuelLevel--
println(car.fuelLevel) //99
try {
    car.color = ""
} catch(ex: Exception) {
    println(ex.message) //no empty, please //message 속성을 이용 - getMessage()가 아닌
}
println(car.color) //Green
```

## 접근 제어자

- 클래스의 속성과 메소드는 `public`이 기본
- `public`, `private`, `protected`, `internal` 네 개의 접근 제어자가 있다.
    - `protected` : 파생(자식) 클래스들의 메소드가 속성에 접근할 수 있는 권한을 준다.
    - `internal` : 같은 모듈에 있는 모든 코드에서 속성이나 메소드에 접근이 가능하다.
        - 모듈이란 ? 함께 컴파일된 모든 소스 코드
        - internal 접근 제어자는 바이트코드에 직접 나타나지 않는다. internal은 네이밍 컨벤션을 이용해서 코틀린 컴파일러에 의해 다뤄지고, 실행 시간 오버헤드가 전혀 없다.
- getter의 접근 권한은 속성의 접근 권한과 동일
- setter의 경우 개발자가 권한을 수정할 수 있다.

```bash
# setter 접근 제어자 변경
var fuelLevel = 100
**private** set #setter를 다시 구현하지 않을 거라면 파라미터인 value와 메소드 바디는 생략하면 된다.
```

## 초기화 코드

- 주 생성자는 첫 번째 줄에 나타난다.
- 생성자를 위해서 파라미터와 속성이 파라미터 리스트로 정의된다.
- 생성자의 파라미터로 전달되지 않는 속성들은 클래스 내부에서 정의된다.
- 객체를 초기화하는 코드가 복잡하다면 생성자용 바디를 만들 수 있다.
- 클래스는 0개 이상의 `init 블록`을 가질 수 있다.
    - 이 블록들은 주 생성자의 실행의 한 부분으로써 실행된다.
    - init 블록 코드는 top-down으로 순차적으로 실행된다.
    - 주 생성자에서 선언된 속성과 파라미터는 클래스 전체에서 사용 가능하기 떄문에 init 블록 어디에서든 속성과 파라미터를 사용할 수 있다.
    - 하지만, **클래스 내부에서 선언된 속성을 사용하기 위해서는 init 블록을 속성 선언 아래에 위치시켜야 한다.**

```kotlin
class Car(val yearOfMake: Int) {
    var fuelLevel = 100
        private set //setter 접근 제어자 변경
    **init {
        if (yearOfMake < 2020) {
            fuelLevel = 90 //fuelLevel 속성에 접근해야만 하기 때문에 fuelLevel을 정의하는 시점보다 init 블록이 앞에 있으면 안 된다.
        }
    }**
}
```

fuelLevel을 정의하는 시점에 처리할 수도 있다.

```kotlin
class Car(val yearOfMake: Int, theColor: String) {
    var fuelLevel = if (yearOfMake < 2020) 90 else 100
        private set
}
```

> 가급적 init 블록은 1개만 만들고, 가능하다면 1개도 만들지 않도록 하라.
생성자에서 최대한 아무런 작업도 안 하는 것이 프로그램의 안정성과 퍼포먼스 측면 모두에서 더 장점이 크다.
> 

## 보조 생성자

주 생성자를 작성하지 않았다면 코틀린은 아규먼트가 없는 기본 생성자를 생성한다.

주 생성자가 모든 파라미터를 위한 기본 아규먼트를 가지고 있다면 코틀린은 주 생성자와 함께 아규먼트가 없는 생성자를 생성한다. 이렇게 만드는 생성자를 **보조 생성자**라고 한다.

- **보조 생성자는 주 생성자를 호출하거나, 다른 보조 생성자를 호출해야만 한다.**
- **보조 생성자에서는 속성을 선언할 수 없다.** (보조 생성자의 파라미터도 `val`이나 `var`를 사용할 수 없다.)
    
    **주 생성자와 클래스 내부에서만 속성을 정의할 수 있다.**
    

- 주 생성자에서의 constructor 키워드는 선택사항
- 보조 생성자는 `constructor` 키워드로 선언
- **생성자끼리 서로를 호출하는 순환이 일어나지 않도록 주의할 것**

```kotlin
class Person(val first: String, val last: String) { //주 생성자 - 주 생성자에서의 constructor 키워드는 선택사항
    var fulltime = true //클래스 내부에서 선언된 속성
    var location: String = "-"
    // 보조 생성자 1
    **constructor**(first: String, last: String, fte: Boolean): this(first, last) { //this() -> 주 생성자 호출
        fulltime = fte
    }
    // 보조 생성자 2
    **constructor**(first: String, last: String, loc: String) : this(first, last, false) {//this() -> 보조 생성자 1 호출
        location = loc
    }
    override fun toString() = "$first $last $fulltime $location"
}

println(Person("Solar", "Kim")) //Solar Kim true -
println(Person("Solar", "Kim", false)) //Solar Kim false -
println(Person("Solar", "Kim", "home")) //Solar Kim false home
```

## 인스턴스 메소드 정의

- 클래스 안의 메소드 정의 : `fun` 키워드
- 메소드는 기본적으로 `public`
- fun 키워드 앞에 메스드 권한을 설정할 수 있다.
- 속성과 클래스 안의 다른 메소드에 접근할 수 있다.
- 인스턴스를 사용하거나 인스턴스 메소드를 실행하기 위해 `this`를 사용할 수 있다.
- 접근 권한이 없는 메소드(ex. private 메소드)에 접근을 시도하면 컴파일 오류가 난다.

```kotlin
class Person(val first: String, val last: String) {
    **internal** fun fullName() = "$last, $first"
    **private** fun yearsOfService(): Int = throw RuntimeException("Not implemented yet")
}

val solar = Person("Solar", "Kim")
println(solar.fullName())
//println(solar.yearsOfService()) //ERROR. Cannot access 'yearsOfService'
```

코틀린은 컴파일 시간에 클래스를 지우는 특별한 기능을 가지고 있다. “인라인 클래스”에 대해 알아보자

## 인라인 클래스

디자인 시 클래스와 프리미티브 타입 중 어떤 것을 사용할지 논쟁이 된다. **inline 클래스**는 균형을 잡게 해주는 좋은 기능이다.

**컴파일 시간에는 클래스의 장점을 취할 수 있고, 실행 시간에는 프리미티브 타입으로 취급된다.** (바이트코드로 변환되었을 때 프리미티브 타입으로 변경되는 것)

inline 함수를 호출하면 바디로 변경되기 때문에 함수 호출로 인한 오버헤드가 발생되지 않는다. 이와 유사하게 inline 클래스는 사용되는 기본 멤버로 확장되거나 대체된다.

```kotlin
//inline 클래스로 만들어진 SSN 클래스
**inline** class SSN(val id: String)
fun receiveSSN(ssn: SSN) {
    println("Received $ssn")
}
```

위 코드를 `-XXLanguage:+InlineClasses` 커맨드라인 옵션을 주고 컴파일하면 receiveSSN() 함수는 SSN이 아닌 String을 받도록 변경되어 컴파일된다. 하지만 코틀린 컴파일러는 receiveSSN() 함수를 호출할 때 raw 문자열이 아닌 SSN 인스턴스를 이용했는지를 검증한다.

```kotlin
 kotlinc-jvm -XXLanguage:+InlineClasses SSN.kt
warning: ATTENTION!
This build uses unsafe internal compiler arguments:

-XXLanguage:+InlineClasses

This mode is not recommended for production use,
as no stability/compatibility guarantees are given on
compiler or generated code. Use it at your own risk!

SSN.kt:4:1: warning: 'inline' modifier is deprecated. Use 'value' instead
inline class SSN(val id: String)
^
```

> 지금도 되는지 확인 필요
> 

컴파일러가 SSN의 인스턴스가 receiveSSN()으로 전달도리 수 있다는 검증을 마치면 검증이 끝난 String 인스턴스를 receiveSSN() 함수에 직접 전달해 메모리와 객체 생성 측면에서의 잠재적인 오버헤드와 wrapper를 제거한다.

inline 클래스는 속성과 메소드를 가질 수 있고, 인터페이스를 구현할 수도 있다. 내부를 살펴보면 메소드는 프리미티브 타입을 받는 static 메소드가 inline 클래스로 둘러싸여있따. inline 클래스는 final이 되어야 하고, 다른 클래스에 의해서 확장될 수 없다.

# 7-3. 컴패니언 객체와 클래스 멤버

코틀린에서는 fun 키워드 앞에 `static` 키워드를 사용할 수 없다. 코틀린은 클래스 멤버를 생성하도록 컴패니언 객체를 제공한다.

**속성이나 메소드가 클래스 레벨에서 필요하고, 클래스의 특정 인스턴스와는 관련이 없어야 한다면(like, 자바의 static 속성, 메소드) 클래스 안에 만들 수 없고, 컴패니언 객체로 만든다.**

- 컴패니언 객체는 클래스 안에 정의한 싱글톤이다.
- 컴패니언 객체는 인터페이스를 구현할 수도 있고 다른 클래스를 확장할 수 도 있다.

## 클래스 레벨 멤버

- `companion object{}` 키워드
- 클래스 이름을 참조로 하여 접근할 수 있다. (인스턴스를 이용해서 접근 불가)

```kotlin
//컴패니언 객체와 클래스 멤버
class MachineOperator(val name: String) {
    fun checkin() = checkedIn++
    fun checkout() = checkedIn--
    companion object { //컴페니언 객체
        var checkedIn = 0 //클래스 레벨 속성
        fun minimumBreak() = "15 minutes every 2 hours" //클래스 레벨 메소드
    }
}

val solarMachine = MachineOperator("Solar").checkin()
println(MachineOperator.minimumBreak()) //15 minutes every 2 hours
println(MachineOperator.checkedIn) //1
//println(solarMachine.minimumBreak()) //ERROR. 컴패니언 메소드는 인스턴스를 이용해서 접근할 수 없다.
```

멀티 스레드인 경우 컴패니언 객체에 속성을 사용하면 스레드 안정성 문제를 발생시킬 수 있으니 주의하자.

## 컴패니언에 접근하기

- 컴패니언 객체 자체의 참조가 필요한 경우 클래스에 `Companion`을 붙여서 접근할 수 있다.
    - 컴패니언 객체가 인터페이스를 구현하고 있는 경우
    - ex) 함수나 메소드에 특정 인터페이스를 구현한 싱글톤 객체가 필요한 경우

```kotlin
//컴패니언 객체와 클래스 멤버
class MachineOperator(val name: String) {
    fun checkin() = checkedIn++
    fun checkout() = checkedIn--

    //컴페니언 객체
//    companion object { //1. 컴패니언 객체에 이름이 없는 경우
    companion object MachineOperatorFacotry{ //2. 컴패니언 객체에 이름을 지정
        var checkedIn = 0 //클래스 레벨 속성
        fun minimumBreak() = "15 minutes every 2 hours" //클래스 레벨 메소드
    }
}

//컴패니언에 접근하는 방법
//val ref = MachineOperator.Companion //1. Companion은 컴패니언 객체에 명확한 이름이 없을 경우에만 사용
val ref = MachineOperator.MachineOperatorFacotry //2. 컴패니언 객체에 지정된 이름을 사용. Companion은 사용 불가
println(ref.checkedIn)
```

## 팩토리로 사용하는 컴패니언

- 컴패니언 객체는 클래스의 팩토리로 사용할 수 있다.
- 생성자는 객체를 유효한 상태로 초기화해 준다. 하지만 **객체를 사용 가능한 상태로 만들기까지 사전 단계가 필요한 경우가 있다.**
    
    ex) 객체를 이벤트 핸들러에 등록하거나 타이머에 등록해서 실행시키는 경우
    
    - 부작용
        
        생성자 안에서 (이벤트 핸들러나 타이머에) 등록 하는 것은 좋은 생각이 아니다. 생성자의 작업이 완료되기 전에 객체가 사용 가능해지는 상황이 발생할 수 있다.
        
        생성자의 작업 완료 이후 등록 메소드를 호출하는 것 역시 좋은 생각이 아니다.
        
        클래스를 사용하는 사람이 등록을 까먹거나 등록 이전에 다른 메소드를 실행시키는 경우가 생길 수도 있다.
        
    - 해결책
        
        이런 경우 팩토리처럼 동작하는 클래스의 컴패니언 객체를 설계하는 것을 고려해볼 수 있다.
        

컴패니언을 팩토리로 사용하기

1. 클래스에 privatre 생성자를 만든다.
    
    클래스 외부에서 직접 인스턴스를 생성할 수 없다.
    
2. 컴패니언 객체에서 생성된 인스턴스를 리턴하기 전에 인스턴스를 처리하는 메소드를 하나 이상 생성한다.

MachineOperator 클래스가 팩토리를 사용하도록 변경하자

```kotlin
class MachineOperator private constructor(val name: String) { //1.클래스에 privatre 생성자를 만든다.
    fun checkin() = checkedIn++
    fun checkout() = checkedIn--

    //컴페니언 객체
    companion object {
        var checkedIn = 0 //클래스 레벨 속성
        fun minimumBreak() = "15 minutes every 2 hours" //클래스 레벨 메소드

        //팩토리
        fun create(name: String): MachineOperator {
            val instance = MachineOperator(name)
            instance.checkin() //인스턴스를 리턴하기 전에 사전 작업
            return instance
        }
    }
}

val operator = MachineOperator.create("Solar") //인스턴스를 생성하기 위해 create()을 사용해야만 한다.
println(MachineOperator.checkedIn) //1
println(operator.name) //Solar
```

## Static과는 다르다

- 컴패니언의 메소드가 클래스의 static 메소드가 된다고 생각하면 안 된다.

컴패니언 객체의 멤버에 접근하면 코틀린 컴파일러는 싱글톤 객체로 라우팅을 한다. 그런데 Java와의 상호 운용성 측면에서 봤을 때 이런 동작은 문제를 야기할 수 있다. 특히 프로그래머가 static 메소드를 기대하고 있을 경우에 그럴 가능성이 크다. `@표기` 가 이런 문제를 해결할 때 유용하다.

> @표기는 17-3. static 메소드 생성에서 배운다.
> 

# 7-4. 제네릭 클래스 생성

코틀린의 제네릭 클래스는 여러 부분에서 Java와 유사하다. 하지만 **가변성**과 **제약**들은 다르게 선언되었다.

동일한 타입의 객체를 2개 소유하는 `PriorityPair` 클래스를 만들면서 제네릭 클래스를 사용해보자

- 큰 객체가 첫 번째, 작은 객체가 두 번째에 오도록 정렬된다.
- 객체의 순서를 정하기 위해서 `Comparable<T>` 인터페이스의 `compareTo()` 메소드를 사용
- 객체들이 정렬될 것이기 때문에 파라미터 클래스는 Comparable<T> 인터페이스를 구현하기 위해 제한되어야 한다.
- 클래스는 읽기전용이어야 하고 쓸 수 없어야 한다.
- 코틀린의 Pair 클래스가 `class Pair<out A, outt B>`로 정의되어 있듯 파라미터 타입에 `out` 어노테이션을 쓰고 싶어질 수 있지만 우리가 만드는 클래스의 속성은 `Comparable<T>` 인터페이스의 `compareTo()` 메소드에 전달되어야 하기 때문에 우리는 `out` 키워드를 사용할 수 없다.
    
    > Comparable<T> 의 인터페이스를 구현한 타입만으로 제한해야 해서 ?
    > 

```kotlin
// 파라미터 타입과 제약 조건 T: Comparable<T>
class PriorityPair<**T: Comparable<T>**>(member1: T, member2: T) {
    val first: T
    val second: T
    init {
        if (member1 **>=** member2) { // 객체 비교 >= 연산자 //12-1 연산자 오버로딩 참조
            first = member1
            second = member2
        } else {
            first = member2
            second = member1
        }
    }

    override fun toString() = "$first, $second"
}

println(PriorityPair(2, 1))         //2, 1
println(PriorityPair("A", "B"))     //B, A
```

PriorityPair<T>의 인스턴스는 Comparable<T>의 인터페이스를 구현하고 있는 타입이라면 어떤 타입이든 이용해서 만들 수 있다.

제네릭 클래스는 일반적인 클래스를 만드는 문법을 기반으로 가변성과 제약조건을 추가해서 정의한다. **제네릭 클래스를 디자인할 때는 특별히 더 많은 테스트를 진행해서 제네릭 클래스가 특정 타입에서도 정확히 동작하는지를 확인해야 한다.**

# 7-5. 데이터 클래스

- (특정한 행동, 동작보다는) 데이터를 옮기는 데 특화된 클래스이다.
- 주 생성자에는 `val`이나 `var`를 사용한 속성 정의가 적어도 하나 이상 필요하다.
    - 데이터 클래스에서는  `val`이나 `var`를 사용할 수 없다.
- 바디 `{}` 안에 속성이나 메소드를 추가할 수 있다.
- 각각의 데이터 클래스에 코틀린은 자동으로 `equals()` , `hashCode()`, `toString()`, `copy()` 메소드를 만들어준다.

```kotlin
data class Task(val id: Int, val name: String, val completed: Boolean, val assigned: Boolean)

val task1 = Task(1, "Create Project", false, true)
println(task1) //Task(id=1, name=Create Project, completed=false, assigned=true)
println("Name: ${task1.name}") //Name: Create Project
```

- copy() : 대상 객체의 모든 속성을 복사해서 새 객체를 생성하는 메소드
    - 주 생성자에 생성된 속성뿐만 아니라 클래스 안에서 정의된 속성도 포함한다.
    - 프리미티브와 참조에 대한 쉘로우 카피만 가능하다.
    - 이런 점은 내부의 모든 객체가 이뮤터블인 경우라면 문제가 되지 않는다.

```kotlin
val task1Completed = task1.copy(completed = true, assigned = false) //복사하면서 속성 2개를 변경
println(task1Completed) //Task(id=1, name=Create Project, completed=true, assigned=false)
```

- componentN() : 주 생성자에 의해서 정의된 각각의 속성에 접근할 수 있게 해주는 메소드
    - 주 목적은 **구조분해(destructuring)**이다.

```kotlin
val id = task1.id
val isAssigned = task1.assigned
println("Id: $id Assigned: $isAssigned") //Id: 1 Assigned: true
```

데이터 클래스의 구조분해 기능

- 주 생성자가 만든 속성 순서와 **동일한 속성 순서**로 속성을 추출
- 언더스코어(`_`) : skip할 속성

```kotlin
val (id2, _, _, isAssigned2) = task1
println("Id2: $id2 Assigned2: $isAssigned2") //Id2: 1 Assigned2: true
```

지역변수 id2는 task1의 속성 id에 할당된 값(이렇게 하기 위해서 component1() 메소드를 인보크한다.)을 할당했다. isAssigned2에 할당할 때는 component4()메소드를 사용해서 할당했다.

## 한계

코틀린의 데이터 클래스 구조분해에는 중대한 **한계**가 있다.

주 생성자가 만든 속성 순서와 **동일한 속성 순서**로 속성을 추출하기 때문에 개발자가 현재 파라미터 사이에 새로운 파라미터를 넣게 된다면 끔찍한 결과가 나올 것이다.

## 데이터 클래스를 사용하면 좋을 상황

- 행동, 동작보다는 데이터 자체에 집중된 모델링을 할 경우
- `equals()` , `hashCode()`, `toString()`, `copy()` 가 생성되길 원하거나 `copy()` 만 생성되길 원할 경우
    
    (해당 메소드들은 원한다면 오버라이드해 사용할 수도 있다.)
    
- 주 생성자에 적어도 하나 이상의 속성이 포함되어야 할 경우
    
    (아규먼트가 없는 생성자는 데이터 클래스에서 불가능하다.)
    
- 주 생성자를 속성만으로 구성해야 할 경우
- 구조분해 기능을 이용해서 데이터를 쉽게 추출하고 싶은 경우
    
    주의!!! 주 생성자가 만든 속성 순서에 기반한 것이라는 점 (속성의 이름이 아닌)